### PR TITLE
Improve screenshot method with error handling

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -1111,10 +1111,23 @@ export class CometCDPClient {
    * Capture screenshot
    */
   async screenshot(format: "png" | "jpeg" = "png"): Promise<ScreenshotResult> {
-    this.ensureConnected();
-    return this.client!.Page.captureScreenshot({ format }) as Promise<ScreenshotResult>;
+    await this.ensureConnected();
+    
+    try {
+      const result = await this.client!.Page.captureScreenshot({ 
+        format,
+        captureBeyondViewport: false
+      });
+      
+      if (!result || !result.data) {
+        throw new Error("Screenshot returned no data");
+      }
+      
+      return { data: result.data };
+    } catch (error) {
+      throw new Error(`Screenshot failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
-
   /**
    * Execute JavaScript in the page context
    */


### PR DESCRIPTION
## Description
This PR fixes the screenshot functionality issue reported in #2.

## Problem
The `screenshot` method in `cdp-client.ts` had several issues:
- Missing `await` on `ensureConnected()` call
- No error handling for CDP operations
- Type assertion hiding potential errors
- No validation of returned data

## Solution
This PR implements:
- Proper async/await pattern with `ensureConnected()`
- Try-catch block for error handling
- CDP options configuration (`captureBeyondViewport: false`)
- Data validation before returning
- Descriptive error messages

## Changes
- Added `await` before `this.ensureConnected()` on line 1114
- Wrapped screenshot logic in try-catch block (lines 1116-1128)
- Added proper error handling with descriptive messages
- Added data validation check

## Testing
Tested on Windows platform with various screenshot operations.

Fixes #2