### PR TITLE
fix(screenshot): handle 0x0 viewport on hidden targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "chrome-remote-interface": "^0.33.2"
+        "chrome-remote-interface": "^0.34.0"
       },
       "bin": {
         "perplexity-comet-mcp": "dist/index.js"
@@ -1064,9 +1064,9 @@
       }
     },
     "node_modules/chrome-remote-interface": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz",
-      "integrity": "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
+      "integrity": "sha512-rTTcTZ3zemx8I+nvBii7d8BAF0Ms8LLEroypfvwwZOwSpyNGLE28nStXyCA6VwGp2YSQfmCrQH21F/E+oBFvMw==",
       "license": "MIT",
       "dependencies": {
         "commander": "2.11.x",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "chrome-remote-interface": "^0.33.2"
+    "chrome-remote-interface": "^0.34.0"
   },
   "devDependencies": {
     "@types/chrome-remote-interface": "^0.33.0",

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -1112,7 +1112,39 @@ export class CometCDPClient {
    */
   async screenshot(format: "png" | "jpeg" = "png"): Promise<ScreenshotResult> {
     this.ensureConnected();
-    return this.client!.Page.captureScreenshot({ format }) as Promise<ScreenshotResult>;
+
+    try { await this.client!.Page.bringToFront(); } catch { /* not all targets support it */ }
+
+    // Hidden targets (e.g. the Perplexity sidecar panel) can report a 0x0
+    // layout viewport in some Comet window states (cold launch, no real
+    // browsing tabs in front). When the viewport is 0x0,
+    // Page.captureScreenshot waits for compositor frames that never arrive
+    // and stalls for ~2 minutes. Detect via Page.getLayoutMetrics() and
+    // supply an explicit clip + captureBeyondViewport so the renderer
+    // produces a frame immediately.
+    let clip: { x: number; y: number; width: number; height: number; scale: number } | undefined;
+    try {
+      const metrics = await this.client!.Page.getLayoutMetrics();
+      const v = metrics.cssLayoutViewport ?? metrics.layoutViewport;
+      if (!v?.clientWidth || !v?.clientHeight) {
+        clip = { x: 0, y: 0, width: 1280, height: 800, scale: 1 };
+      }
+    } catch {
+      clip = { x: 0, y: 0, width: 1280, height: 800, scale: 1 };
+    }
+
+    const result = await this.client!.Page.captureScreenshot({
+      format,
+      ...(clip ? { captureBeyondViewport: true, clip } : {}),
+    }) as ScreenshotResult;
+
+    if (!result?.data) {
+      throw new Error(
+        "Screenshot returned empty data. Ensure you're connected to a visible tab with content.",
+      );
+    }
+
+    return result;
   }
 
   /**

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -18,10 +18,16 @@ import type {
 // Hidden targets (e.g. the Perplexity sidecar panel) can report a 0x0 layout
 // viewport in some Comet window states (cold launch, no real browsing tabs in
 // front). When that happens, Page.captureScreenshot waits for compositor
-// frames that never arrive and stalls for ~2 minutes. Detecting any
-// degenerate dimension via Page.getLayoutMetrics() and supplying an explicit
-// clip + captureBeyondViewport=true makes the renderer produce a frame
-// immediately.
+// frames that never arrive and stalls for ~2 minutes. Detecting that state
+// via Page.getLayoutMetrics() and supplying an explicit clip +
+// captureBeyondViewport=true makes the renderer produce a frame immediately.
+//
+// The predicate is intentionally tight: both dimensions must be zero. Live
+// CDP testing confirmed that 0x0 is the only reproducible viewport state
+// that triggers the stall — Chromium's Emulation.setDeviceMetricsOverride
+// rejects single-zero dimensions and falls back to the natural viewport,
+// and the natural 0x0 case is "no layout computed yet" (an all-or-nothing
+// state). A 0xN or Nx0 viewport is not a state we can observe in practice.
 const SCREENSHOT_FALLBACK_CLIP = {
   x: 0,
   y: 0,
@@ -63,7 +69,7 @@ export async function captureScreenshotWithFallback(
   try {
     const metrics = await page.getLayoutMetrics();
     const v = metrics.cssLayoutViewport ?? metrics.layoutViewport;
-    if (!v?.clientWidth || !v?.clientHeight) {
+    if (!v?.clientWidth && !v?.clientHeight) {
       clip = SCREENSHOT_FALLBACK_CLIP;
     }
   } catch {

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -15,6 +15,19 @@ import type {
   TabContext,
 } from "./types.js";
 
+// chrome-remote-interface@^0.34.0 exposes `ProtocolError` at runtime
+// (`module.exports.ProtocolError = ...`), but @types/chrome-remote-interface
+// doesn't declare it yet. Cast at import so `instanceof` typechecks; remove
+// the cast once DefinitelyTyped/DefinitelyTyped#74992 lands and we pick up
+// the updated @types.
+interface CdpProtocolError extends Error {
+  request: { method: string; params?: unknown };
+  response: CDP.SendError;
+}
+const ProtocolError = (CDP as unknown as {
+  ProtocolError: new (...args: unknown[]) => CdpProtocolError;
+}).ProtocolError;
+
 // Hidden targets (e.g. the Perplexity sidecar panel) can report a 0x0 layout
 // viewport in some Comet window states (cold launch, no real browsing tabs in
 // front). When that happens, Page.captureScreenshot waits for compositor
@@ -72,8 +85,17 @@ export async function captureScreenshotWithFallback(
     if (!v?.clientWidth && !v?.clientHeight) {
       clip = SCREENSHOT_FALLBACK_CLIP;
     }
-  } catch {
-    clip = SCREENSHOT_FALLBACK_CLIP;
+  } catch (err) {
+    // Chrome-side rejection (e.g. method unsupported on a non-page target):
+    // apply the fallback so captureScreenshot can still produce a frame.
+    // Anything else (websocket dropped, unexpected throw): propagate — the
+    // next CDP call would fail the same way, and masking with a synthetic
+    // 1280x800 capture would hide a real transport-level failure.
+    if (err instanceof ProtocolError) {
+      clip = SCREENSHOT_FALLBACK_CLIP;
+    } else {
+      throw err;
+    }
   }
 
   const result = await page.captureScreenshot({

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -15,6 +15,75 @@ import type {
   TabContext,
 } from "./types.js";
 
+// Hidden targets (e.g. the Perplexity sidecar panel) can report a 0x0 layout
+// viewport in some Comet window states (cold launch, no real browsing tabs in
+// front). When that happens, Page.captureScreenshot waits for compositor
+// frames that never arrive and stalls for ~2 minutes. Detecting any
+// degenerate dimension via Page.getLayoutMetrics() and supplying an explicit
+// clip + captureBeyondViewport=true makes the renderer produce a frame
+// immediately.
+const SCREENSHOT_FALLBACK_CLIP = {
+  x: 0,
+  y: 0,
+  width: 1280,
+  height: 800,
+  scale: 1,
+} as const;
+
+/**
+ * The slice of the CDP Page domain that `captureScreenshotWithFallback` uses.
+ * Lets unit tests substitute a hand-written fake without dragging in the full
+ * `chrome-remote-interface` Page surface.
+ */
+export interface ScreenshotPageAPI {
+  bringToFront(): Promise<unknown>;
+  getLayoutMetrics(): Promise<{
+    cssLayoutViewport?: { clientWidth: number; clientHeight: number };
+    layoutViewport?: { clientWidth: number; clientHeight: number };
+  }>;
+  captureScreenshot(opts: {
+    format: "png" | "jpeg";
+    captureBeyondViewport?: boolean;
+    clip?: typeof SCREENSHOT_FALLBACK_CLIP;
+  }): Promise<ScreenshotResult>;
+}
+
+/**
+ * Capture a screenshot, falling back to an explicit clip when the layout
+ * viewport is degenerate. Extracted as a free function so it can be unit
+ * tested against a fake Page without a live CDP connection.
+ */
+export async function captureScreenshotWithFallback(
+  page: ScreenshotPageAPI,
+  format: "png" | "jpeg" = "png",
+): Promise<ScreenshotResult> {
+  try { await page.bringToFront(); } catch { /* not all targets support it */ }
+
+  let clip: typeof SCREENSHOT_FALLBACK_CLIP | undefined;
+  try {
+    const metrics = await page.getLayoutMetrics();
+    const v = metrics.cssLayoutViewport ?? metrics.layoutViewport;
+    if (!v?.clientWidth || !v?.clientHeight) {
+      clip = SCREENSHOT_FALLBACK_CLIP;
+    }
+  } catch {
+    clip = SCREENSHOT_FALLBACK_CLIP;
+  }
+
+  const result = await page.captureScreenshot({
+    format,
+    ...(clip ? { captureBeyondViewport: true, clip } : {}),
+  });
+
+  if (!result?.data) {
+    throw new Error(
+      "Screenshot returned empty data. Ensure you're connected to a visible tab with content.",
+    );
+  }
+
+  return result;
+}
+
 // Detect if running in WSL (must be before windowsFetch)
 function isWSL(): boolean {
   if (platform() !== 'linux') return false;
@@ -1112,39 +1181,7 @@ export class CometCDPClient {
    */
   async screenshot(format: "png" | "jpeg" = "png"): Promise<ScreenshotResult> {
     this.ensureConnected();
-
-    try { await this.client!.Page.bringToFront(); } catch { /* not all targets support it */ }
-
-    // Hidden targets (e.g. the Perplexity sidecar panel) can report a 0x0
-    // layout viewport in some Comet window states (cold launch, no real
-    // browsing tabs in front). When the viewport is 0x0,
-    // Page.captureScreenshot waits for compositor frames that never arrive
-    // and stalls for ~2 minutes. Detect via Page.getLayoutMetrics() and
-    // supply an explicit clip + captureBeyondViewport so the renderer
-    // produces a frame immediately.
-    let clip: { x: number; y: number; width: number; height: number; scale: number } | undefined;
-    try {
-      const metrics = await this.client!.Page.getLayoutMetrics();
-      const v = metrics.cssLayoutViewport ?? metrics.layoutViewport;
-      if (!v?.clientWidth || !v?.clientHeight) {
-        clip = { x: 0, y: 0, width: 1280, height: 800, scale: 1 };
-      }
-    } catch {
-      clip = { x: 0, y: 0, width: 1280, height: 800, scale: 1 };
-    }
-
-    const result = await this.client!.Page.captureScreenshot({
-      format,
-      ...(clip ? { captureBeyondViewport: true, clip } : {}),
-    }) as ScreenshotResult;
-
-    if (!result?.data) {
-      throw new Error(
-        "Screenshot returned empty data. Ensure you're connected to a visible tab with content.",
-      );
-    }
-
-    return result;
+    return captureScreenshotWithFallback(this.client!.Page, format);
   }
 
   /**

--- a/tests/unit/cdp-client.screenshot.test.ts
+++ b/tests/unit/cdp-client.screenshot.test.ts
@@ -15,10 +15,11 @@ const FALLBACK_CLIP = {
 // reproducible state that hangs Page.captureScreenshot: Chromium's
 // Emulation.setDeviceMetricsOverride rejects single-zero dimensions, and
 // the natural 0×0 case (visibilityState='hidden' with no layout computed)
-// is all-or-nothing. So 0×N and N×0 are exercised here for boundary
-// coverage but treated as non-degenerate; if the wrapper ever observed
-// one in the wild, we'd trust the reported dimensions rather than fall
-// back.
+// is all-or-nothing. PNG/JPEG headers also require both dimensions to be
+// >= 1, so a zero-dim image isn't a valid output format. The 0×N and N×0
+// boundary tests below therefore expect the wrapper to NOT apply the
+// fallback (no synthetic 1280×800 masking the anomaly) and to surface
+// the inevitable encoder failure via the empty-data guard.
 describe("captureScreenshotWithFallback — non-degenerate viewport", () => {
   it("forwards format and supplies no clip when the cssLayoutViewport is non-zero", async () => {
     const page = new FakeScreenshotPage();
@@ -39,21 +40,27 @@ describe("captureScreenshotWithFallback — non-degenerate viewport", () => {
     expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
   });
 
-  it("does NOT supply a fallback clip when only width is 0", async () => {
+  it("passes through (no fallback) and fails loudly when only width is 0", async () => {
     const page = new FakeScreenshotPage();
     page.setMetrics({ cssLayoutViewport: { clientWidth: 0, clientHeight: 800 } });
+    // Model real-browser behavior: no encoder can produce output for a
+    // zero-dim image, so the captureScreenshot call returns empty data.
+    page.setScreenshotData(undefined);
 
-    await captureScreenshotWithFallback(page, "png");
-
+    await expect(captureScreenshotWithFallback(page, "png")).rejects.toThrow(
+      /empty data/i,
+    );
     expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
   });
 
-  it("does NOT supply a fallback clip when only height is 0", async () => {
+  it("passes through (no fallback) and fails loudly when only height is 0", async () => {
     const page = new FakeScreenshotPage();
     page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 0 } });
+    page.setScreenshotData(undefined);
 
-    await captureScreenshotWithFallback(page, "png");
-
+    await expect(captureScreenshotWithFallback(page, "png")).rejects.toThrow(
+      /empty data/i,
+    );
     expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
   });
 

--- a/tests/unit/cdp-client.screenshot.test.ts
+++ b/tests/unit/cdp-client.screenshot.test.ts
@@ -94,9 +94,13 @@ describe("captureScreenshotWithFallback — degenerate viewport", () => {
     });
   });
 
-  it("supplies the fallback clip when getLayoutMetrics throws", async () => {
+  // Chrome-side rejection (ProtocolError) on getLayoutMetrics typically
+  // means the method isn't supported on this target type. The wrapper
+  // recovers because captureScreenshot may still succeed at the fallback
+  // dimensions.
+  it("supplies the fallback clip when getLayoutMetrics throws a ProtocolError", async () => {
     const page = new FakeScreenshotPage();
-    page.setMetricsToThrow();
+    page.setMetricsToThrowProtocolError();
 
     await captureScreenshotWithFallback(page, "png");
 
@@ -105,6 +109,19 @@ describe("captureScreenshotWithFallback — degenerate viewport", () => {
       captureBeyondViewport: true,
       clip: FALLBACK_CLIP,
     });
+  });
+
+  // Transport-level or unexpected errors must NOT be masked with a
+  // synthetic 1280x800 capture — propagate so the caller sees the real
+  // failure (websocket dropped, target detached, etc.).
+  it("propagates non-ProtocolError throws from getLayoutMetrics", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetricsToThrowGeneric();
+
+    await expect(captureScreenshotWithFallback(page, "png")).rejects.toThrow(
+      /websocket dropped/i,
+    );
+    expect(page.captureScreenshotCalls).toHaveLength(0);
   });
 
   it("supplies the fallback clip when both viewport fields are absent", async () => {

--- a/tests/unit/cdp-client.screenshot.test.ts
+++ b/tests/unit/cdp-client.screenshot.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { captureScreenshotWithFallback } from "../../src/cdp-client.js";
+import { FakeScreenshotPage } from "./fakes/fake-screenshot-page.js";
+
+const FALLBACK_CLIP = {
+  x: 0,
+  y: 0,
+  width: 1280,
+  height: 800,
+  scale: 1,
+};
+
+describe("captureScreenshotWithFallback — normal viewport", () => {
+  it("forwards format and supplies no clip when the cssLayoutViewport is non-zero", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 768 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls).toHaveLength(1);
+    expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
+  });
+
+  it("falls back to layoutViewport when cssLayoutViewport is missing", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ layoutViewport: { clientWidth: 800, clientHeight: 600 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
+  });
+
+  it("forwards jpeg format unchanged", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 768 } });
+
+    await captureScreenshotWithFallback(page, "jpeg");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({ format: "jpeg" });
+  });
+
+  it("calls bringToFront before capture (best-effort)", async () => {
+    const page = new FakeScreenshotPage();
+    await captureScreenshotWithFallback(page, "png");
+    expect(page.bringToFrontCalls).toBe(1);
+  });
+});
+
+describe("captureScreenshotWithFallback — degenerate viewport", () => {
+  it("supplies the fallback clip + captureBeyondViewport when viewport is 0×0", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 0, clientHeight: 0 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({
+      format: "png",
+      captureBeyondViewport: true,
+      clip: FALLBACK_CLIP,
+    });
+  });
+
+  // The wrapper treats any zero dimension as degenerate (`||` semantics).
+  // This is defensive: a 0×N or N×0 viewport can't produce a useful
+  // screenshot anyway, so falling back to a real frame is preferable to
+  // returning a zero-pixel image.
+  it("supplies the fallback clip when width is 0 but height is non-zero", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 0, clientHeight: 800 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({
+      format: "png",
+      captureBeyondViewport: true,
+      clip: FALLBACK_CLIP,
+    });
+  });
+
+  it("supplies the fallback clip when height is 0 but width is non-zero", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 0 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({
+      format: "png",
+      captureBeyondViewport: true,
+      clip: FALLBACK_CLIP,
+    });
+  });
+
+  it("supplies the fallback clip when getLayoutMetrics throws", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetricsToThrow();
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({
+      format: "png",
+      captureBeyondViewport: true,
+      clip: FALLBACK_CLIP,
+    });
+  });
+
+  it("supplies the fallback clip when both viewport fields are absent", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({});
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({
+      format: "png",
+      captureBeyondViewport: true,
+      clip: FALLBACK_CLIP,
+    });
+  });
+});
+
+describe("captureScreenshotWithFallback — error handling", () => {
+  it("swallows bringToFront errors and continues to capture", async () => {
+    const page = new FakeScreenshotPage();
+    page.setBringToFrontToThrow();
+
+    const result = await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls).toHaveLength(1);
+    expect(result.data).toBeTruthy();
+  });
+
+  it("throws a descriptive error when captureScreenshot returns empty data", async () => {
+    const page = new FakeScreenshotPage();
+    page.setScreenshotData(undefined);
+
+    await expect(captureScreenshotWithFallback(page, "png")).rejects.toThrow(
+      /empty data/i,
+    );
+  });
+});

--- a/tests/unit/cdp-client.screenshot.test.ts
+++ b/tests/unit/cdp-client.screenshot.test.ts
@@ -10,7 +10,16 @@ const FALLBACK_CLIP = {
   scale: 1,
 };
 
-describe("captureScreenshotWithFallback — normal viewport", () => {
+// The predicate that triggers the fallback is `!width && !height` — both
+// dimensions must be zero. Live CDP testing showed 0×0 is the only
+// reproducible state that hangs Page.captureScreenshot: Chromium's
+// Emulation.setDeviceMetricsOverride rejects single-zero dimensions, and
+// the natural 0×0 case (visibilityState='hidden' with no layout computed)
+// is all-or-nothing. So 0×N and N×0 are exercised here for boundary
+// coverage but treated as non-degenerate; if the wrapper ever observed
+// one in the wild, we'd trust the reported dimensions rather than fall
+// back.
+describe("captureScreenshotWithFallback — non-degenerate viewport", () => {
   it("forwards format and supplies no clip when the cssLayoutViewport is non-zero", async () => {
     const page = new FakeScreenshotPage();
     page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 768 } });
@@ -24,6 +33,24 @@ describe("captureScreenshotWithFallback — normal viewport", () => {
   it("falls back to layoutViewport when cssLayoutViewport is missing", async () => {
     const page = new FakeScreenshotPage();
     page.setMetrics({ layoutViewport: { clientWidth: 800, clientHeight: 600 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
+  });
+
+  it("does NOT supply a fallback clip when only width is 0", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 0, clientHeight: 800 } });
+
+    await captureScreenshotWithFallback(page, "png");
+
+    expect(page.captureScreenshotCalls[0]).toEqual({ format: "png" });
+  });
+
+  it("does NOT supply a fallback clip when only height is 0", async () => {
+    const page = new FakeScreenshotPage();
+    page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 0 } });
 
     await captureScreenshotWithFallback(page, "png");
 
@@ -50,36 +77,6 @@ describe("captureScreenshotWithFallback — degenerate viewport", () => {
   it("supplies the fallback clip + captureBeyondViewport when viewport is 0×0", async () => {
     const page = new FakeScreenshotPage();
     page.setMetrics({ cssLayoutViewport: { clientWidth: 0, clientHeight: 0 } });
-
-    await captureScreenshotWithFallback(page, "png");
-
-    expect(page.captureScreenshotCalls[0]).toEqual({
-      format: "png",
-      captureBeyondViewport: true,
-      clip: FALLBACK_CLIP,
-    });
-  });
-
-  // The wrapper treats any zero dimension as degenerate (`||` semantics).
-  // This is defensive: a 0×N or N×0 viewport can't produce a useful
-  // screenshot anyway, so falling back to a real frame is preferable to
-  // returning a zero-pixel image.
-  it("supplies the fallback clip when width is 0 but height is non-zero", async () => {
-    const page = new FakeScreenshotPage();
-    page.setMetrics({ cssLayoutViewport: { clientWidth: 0, clientHeight: 800 } });
-
-    await captureScreenshotWithFallback(page, "png");
-
-    expect(page.captureScreenshotCalls[0]).toEqual({
-      format: "png",
-      captureBeyondViewport: true,
-      clip: FALLBACK_CLIP,
-    });
-  });
-
-  it("supplies the fallback clip when height is 0 but width is non-zero", async () => {
-    const page = new FakeScreenshotPage();
-    page.setMetrics({ cssLayoutViewport: { clientWidth: 1024, clientHeight: 0 } });
 
     await captureScreenshotWithFallback(page, "png");
 

--- a/tests/unit/fakes/fake-screenshot-page.ts
+++ b/tests/unit/fakes/fake-screenshot-page.ts
@@ -1,0 +1,58 @@
+// Minimal fake of the CDP `Page` slice that `captureScreenshotWithFallback`
+// uses. Implements just `bringToFront`, `getLayoutMetrics`, and
+// `captureScreenshot` — enough to satisfy the `ScreenshotPageAPI` type — and
+// records every call so tests can assert on the args.
+
+import type { ScreenshotPageAPI } from "../../../src/cdp-client.js";
+import type { ScreenshotResult } from "../../../src/types.js";
+
+type LayoutMetrics = Awaited<ReturnType<ScreenshotPageAPI["getLayoutMetrics"]>>;
+type CaptureScreenshotArgs = Parameters<ScreenshotPageAPI["captureScreenshot"]>[0];
+
+export class FakeScreenshotPage implements ScreenshotPageAPI {
+  public bringToFrontCalls = 0;
+  public readonly captureScreenshotCalls: CaptureScreenshotArgs[] = [];
+
+  private bringToFrontShouldThrow = false;
+  private metricsResponse: LayoutMetrics = {
+    cssLayoutViewport: { clientWidth: 1024, clientHeight: 768 },
+  };
+  private metricsShouldThrow = false;
+  private screenshotData: string | undefined = "ZmFrZS1zY3JlZW5zaG90LWRhdGE="; // base64 "fake-screenshot-data"
+
+  setMetrics(metrics: LayoutMetrics): void {
+    this.metricsResponse = metrics;
+    this.metricsShouldThrow = false;
+  }
+
+  setMetricsToThrow(): void {
+    this.metricsShouldThrow = true;
+  }
+
+  setBringToFrontToThrow(): void {
+    this.bringToFrontShouldThrow = true;
+  }
+
+  setScreenshotData(data: string | undefined): void {
+    this.screenshotData = data;
+  }
+
+  async bringToFront(): Promise<void> {
+    this.bringToFrontCalls++;
+    if (this.bringToFrontShouldThrow) {
+      throw new Error("bringToFront not supported on this target");
+    }
+  }
+
+  async getLayoutMetrics(): Promise<LayoutMetrics> {
+    if (this.metricsShouldThrow) {
+      throw new Error("getLayoutMetrics unsupported");
+    }
+    return this.metricsResponse;
+  }
+
+  async captureScreenshot(opts: CaptureScreenshotArgs): Promise<ScreenshotResult> {
+    this.captureScreenshotCalls.push(opts);
+    return { data: this.screenshotData } as ScreenshotResult;
+  }
+}

--- a/tests/unit/fakes/fake-screenshot-page.ts
+++ b/tests/unit/fakes/fake-screenshot-page.ts
@@ -3,11 +3,24 @@
 // `captureScreenshot` — enough to satisfy the `ScreenshotPageAPI` type — and
 // records every call so tests can assert on the args.
 
+import CDP from "chrome-remote-interface";
 import type { ScreenshotPageAPI } from "../../../src/cdp-client.js";
 import type { ScreenshotResult } from "../../../src/types.js";
 
+// chrome-remote-interface@^0.34.0 exposes ProtocolError but @types doesn't
+// declare it; mirror the cast pattern used in src/cdp-client.ts so tests can
+// construct one for the discriminator check.
+const ProtocolError = (CDP as unknown as {
+  ProtocolError: new (
+    request: { method: string },
+    response: { code: number; message: string; data?: string },
+  ) => Error;
+}).ProtocolError;
+
 type LayoutMetrics = Awaited<ReturnType<ScreenshotPageAPI["getLayoutMetrics"]>>;
 type CaptureScreenshotArgs = Parameters<ScreenshotPageAPI["captureScreenshot"]>[0];
+
+type ThrowMode = "none" | "protocol-error" | "generic";
 
 export class FakeScreenshotPage implements ScreenshotPageAPI {
   public bringToFrontCalls = 0;
@@ -17,16 +30,24 @@ export class FakeScreenshotPage implements ScreenshotPageAPI {
   private metricsResponse: LayoutMetrics = {
     cssLayoutViewport: { clientWidth: 1024, clientHeight: 768 },
   };
-  private metricsShouldThrow = false;
+  private metricsThrowMode: ThrowMode = "none";
   private screenshotData: string | undefined = "ZmFrZS1zY3JlZW5zaG90LWRhdGE="; // base64 "fake-screenshot-data"
 
   setMetrics(metrics: LayoutMetrics): void {
     this.metricsResponse = metrics;
-    this.metricsShouldThrow = false;
+    this.metricsThrowMode = "none";
   }
 
-  setMetricsToThrow(): void {
-    this.metricsShouldThrow = true;
+  /** Make `getLayoutMetrics` throw a `CDP.ProtocolError` — models Chrome
+   * rejecting the method (e.g. unsupported on a non-page target). */
+  setMetricsToThrowProtocolError(): void {
+    this.metricsThrowMode = "protocol-error";
+  }
+
+  /** Make `getLayoutMetrics` throw a plain `Error` — models transport-level
+   * or unexpected failures that should propagate, not trigger the fallback. */
+  setMetricsToThrowGeneric(): void {
+    this.metricsThrowMode = "generic";
   }
 
   setBringToFrontToThrow(): void {
@@ -45,8 +66,14 @@ export class FakeScreenshotPage implements ScreenshotPageAPI {
   }
 
   async getLayoutMetrics(): Promise<LayoutMetrics> {
-    if (this.metricsShouldThrow) {
-      throw new Error("getLayoutMetrics unsupported");
+    if (this.metricsThrowMode === "protocol-error") {
+      throw new ProtocolError(
+        { method: "Page.getLayoutMetrics" },
+        { code: -32601, message: "'Page.getLayoutMetrics' wasn't found" },
+      );
+    }
+    if (this.metricsThrowMode === "generic") {
+      throw new Error("websocket dropped");
     }
     return this.metricsResponse;
   }


### PR DESCRIPTION
## Summary
- Detects zero-size layout viewport via `Page.getLayoutMetrics()` and supplies an explicit `clip` + `captureBeyondViewport: true` so `Page.captureScreenshot` produces a frame immediately instead of stalling
- No-op on real foreground tabs (non-zero layout viewport → clip path doesn't activate)

## Problem
`comet_screenshot` intermittently hangs for ~2 minutes when the MCP attaches to the Perplexity sidecar panel (`https://www.perplexity.ai/sidecar?copilot=true`, `visibilityState='hidden'`) in some Comet window states (cold launch, no real browsing tabs in front).

Two runs on the same machine, same target URL:

| Run | State | layoutViewport | `captureScreenshot` |
|---|---|---|---|
| 1 | Comet freshly launched, no real tabs | 0×0 | ~111s |
| 2 | Comet warm, after some usage | 800×600 CSS / 1600×1200 device | 253ms |

## Root Cause
Without `captureBeyondViewport`, `Page.captureScreenshot` captures the layout viewport and waits for compositor frames. When the layout viewport is 0×0, those frames never arrive and the call hangs.

This is a different symptom from `document.readyState === 'complete'` (PR #4's wait): in run 1 the readyState wait completes in ~6ms and the hang then happens inside `captureScreenshot` itself.

## Fix
```ts
let clip: { x: number; y: number; width: number; height: number; scale: number } | undefined;
try {
  const metrics = await this.client!.Page.getLayoutMetrics();
  const v = metrics.cssLayoutViewport ?? metrics.layoutViewport;
  if (!v?.clientWidth || !v?.clientHeight) {
    clip = { x: 0, y: 0, width: 1280, height: 800, scale: 1 };
  }
} catch {
  clip = { x: 0, y: 0, width: 1280, height: 800, scale: 1 };
}

const result = await this.client!.Page.captureScreenshot({
  format,
  ...(clip ? { captureBeyondViewport: true, clip } : {}),
}) as ScreenshotResult;
```

Also adds:
- `Page.bringToFront()` before capture (best-effort, swallows errors on targets that don't support it)
- Empty-data validation with a descriptive error message

## Test Plan
- [x] Verified ~50ms PNG capture on the 0×0 sidecar target where the previous code hung ~111s
- [x] Verified no-op on a normal foreground tab with non-zero layout viewport (clip path doesn't activate)
- [x] `npm run build` passes

## Context
Replaces #4 with a fix targeting the underlying compositor-frame issue. Discussion: https://github.com/RapierCraft/Perplexity-Comet-MCP/pull/4#issuecomment-4364619838

Closes #2.
Closes #4.