### PR TITLE
chore(deps): drop unused @anthropic-ai/sdk dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "chrome-remote-interface": "^0.33.2"
       },
@@ -27,36 +26,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chrome-remote-interface": "^0.33.2"
   },


### PR DESCRIPTION
## Summary

\`grep -rn anthropic src/ tests/\` returns zero hits — the package is in \`package.json\` but never imported anywhere in the codebase. Likely a leftover from an earlier exploration of routing through the Anthropic API directly (the MCP server now interacts with Perplexity's Comet via CDP, not Anthropic).

Removing it:

- Cuts ~30 MB of transitive packages (\`@types/node\`, \`node-fetch\`, \`agentkeepalive\`, \`formdata-node\`, ...) from every install of the package.
- Speeds up \`npm ci\` in CI noticeably.
- Trims supply-chain attack surface — fewer transitives to monitor.

## Notes on the lockfile

This PR removes the entry from \`package.json\` and the matching top-level entries from \`package-lock.json\`. Some orphan transitive entries remain (\`abort-controller\`, \`node-fetch\`, \`agentkeepalive\`, \`form-data-encoder\`, \`formdata-node\`, \`humanize-ms\`, \`@types/node-fetch\`) and will be flushed on the next \`npm install\` locally.

Happy to either:

- let the lockfile be regenerated on merge, or
- push a follow-up commit removing the orphans explicitly — reviewer's preference.

## Test plan

- [ ] \`npm install\` resolves cleanly (regenerates lock if desired)
- [ ] \`npm ci\` still works (orphans cause no failure with lockfileVersion 3)
- [ ] \`npm run build\` succeeds
- [ ] \`npm run test:unit\` passes

## Related

Last of three small PRs from an audit pass:

- security hardening of \`Runtime.evaluate\` / PowerShell interpolation (separate)
- correctness fixes (separate)
- this PR (cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)