### PR TITLE
fix(upload): allowlist filesystem paths and validate tabId

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -359,7 +359,6 @@ export class CometCDPClient {
   // proven stable, so a flapping link doesn't silently bypass the
   // max-attempts breaker.
   private consecutiveSuccesses: number = 0;
-  private connectionCheckInterval: NodeJS.Timeout | null = null;
   private lastHealthCheck: number = 0;
   private healthCheckCache: boolean = false;
   private readonly HEALTH_CHECK_CACHE_MS: number = 2000; // Cache health check for 2s

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@
 // Claude Code ↔ Perplexity Comet bidirectional interaction
 // Simplified to 6 essential tools
 
-import { readFileSync } from "fs";
+import { readFileSync, existsSync, realpathSync, statSync } from "fs";
 import { fileURLToPath } from "url";
-import { dirname, join } from "path";
+import { dirname, join, resolve as resolvePath, sep as PATH_SEP } from "path";
+import { homedir } from "os";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -38,6 +39,88 @@ function readPackageVersion(): string {
   }
 }
 const SERVER_VERSION = readPackageVersion();
+
+/**
+ * Validate a user-supplied upload path against the optional allowlist root
+ * (`COMET_UPLOAD_ROOT` env). When the env var is set we resolve symlinks
+ * and require the real path to live under the configured root — defends
+ * against an LLM-controlled `filePath` exfiltrating arbitrary local files
+ * (e.g. `~/.ssh/id_rsa`, `~/.aws/credentials`).
+ *
+ * When the env var is unset we keep the previous permissive behaviour
+ * (backward compatibility) but still block a hardcoded denylist of paths
+ * that obviously have no business being uploaded to a webpage.
+ *
+ * Returns the canonical absolute path, or throws with a user-facing message.
+ */
+function validateUploadPath(filePath: string): string {
+  if (!existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+  const real = realpathSync(filePath); // resolve symlinks
+  const stat = statSync(real);
+  if (!stat.isFile()) {
+    throw new Error(`Not a regular file: ${filePath}`);
+  }
+
+  const root = process.env.COMET_UPLOAD_ROOT;
+  if (root) {
+    const realRoot = realpathSync(resolvePath(root));
+    const rootWithSep = realRoot.endsWith(PATH_SEP) ? realRoot : realRoot + PATH_SEP;
+    if (real !== realRoot && !real.startsWith(rootWithSep)) {
+      throw new Error(
+        `Refusing upload: path is outside COMET_UPLOAD_ROOT (${realRoot}). ` +
+        `Resolved path: ${real}`
+      );
+    }
+    return real;
+  }
+
+  // No allowlist configured. Still block obviously-sensitive paths to
+  // make the failure mode at least one step better than "anything goes".
+  const home = homedir();
+  const blockedPrefixes = [
+    resolvePath(home, ".ssh"),
+    resolvePath(home, ".aws"),
+    resolvePath(home, ".config", "gh"),
+    resolvePath(home, ".config", "gcloud"),
+    resolvePath(home, ".gnupg"),
+    resolvePath(home, ".kube"),
+    resolvePath(home, ".docker"),
+    resolvePath(home, "Library", "Keychains"), // macOS
+    "/etc/shadow",
+    "/etc/sudoers",
+    "/root",
+  ];
+  for (const prefix of blockedPrefixes) {
+    const withSep = prefix.endsWith(PATH_SEP) ? prefix : prefix + PATH_SEP;
+    if (real === prefix || real.startsWith(withSep)) {
+      throw new Error(
+        `Refusing upload from sensitive path: ${real}. ` +
+        `Set COMET_UPLOAD_ROOT to an explicit upload directory if this is intentional.`
+      );
+    }
+  }
+
+  console.error(
+    `[comet-mcp] WARN: comet_upload received '${real}' without COMET_UPLOAD_ROOT set. ` +
+    `Consider setting the env var to restrict allowed paths.`
+  );
+  return real;
+}
+
+/**
+ * CDP target IDs are 32-char hex strings (typically uppercase). Reject
+ * obviously-malformed values before passing to `Target.connect/close`,
+ * which otherwise produce cryptic errors and can be tricked into
+ * traversing the local HTTP API surface (`/json/version`, etc.).
+ */
+function validateTabId(tabId: string): string {
+  if (!/^[A-Fa-f0-9-]{16,64}$/.test(tabId)) {
+    throw new Error(`Invalid tabId format: ${tabId}`);
+  }
+  return tabId;
+}
 
 const TOOLS: Tool[] = [
   {
@@ -560,6 +643,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
           case 'switch': {
             if (tabId) {
+              try {
+                validateTabId(tabId);
+              } catch (e: any) {
+                return { content: [{ type: "text", text: `Error: ${e.message}` }], isError: true };
+              }
               await cometClient.connect(tabId);
               return { content: [{ type: "text", text: `Switched to tab: ${tabId}` }] };
             }
@@ -584,6 +672,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }
 
             if (tabId) {
+              try {
+                validateTabId(tabId);
+              } catch (e: any) {
+                return { content: [{ type: "text", text: `Error: ${e.message}` }], isError: true };
+              }
               const success = await cometClient.closeTab(tabId);
               return { content: [{ type: "text", text: success ? `Closed tab: ${tabId}` : `Failed to close tab` }] };
             }
@@ -747,10 +840,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: "Error: filePath is required" }], isError: true };
         }
 
-        // Check if file exists
-        const fs = await import('fs');
-        if (!fs.existsSync(filePath)) {
-          return { content: [{ type: "text", text: `Error: File not found: ${filePath}` }], isError: true };
+        // Validate path: enforce COMET_UPLOAD_ROOT allowlist if set, else
+        // block well-known secret locations. Resolves symlinks. Throws
+        // user-facing message on rejection.
+        let resolvedPath: string;
+        try {
+          resolvedPath = validateUploadPath(filePath);
+        } catch (e: any) {
+          return { content: [{ type: "text", text: `Error: ${e.message}` }], isError: true };
         }
 
         // If checkOnly, just report what file inputs exist
@@ -766,8 +863,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }
         }
 
-        // Perform the upload
-        const result = await cometClient.uploadFile(filePath, selector);
+        // Perform the upload with the canonical resolved path.
+        const result = await cometClient.uploadFile(resolvedPath, selector);
 
         if (result.success) {
           return { content: [{ type: "text", text: result.message }] };


### PR DESCRIPTION
## Summary

\`comet_upload\` accepted any local path and forwarded it to \`DOM.setFileInputFiles\` against whatever page Comet was on. Combined with indirect prompt-injection from page content, this is an arbitrary-file exfiltration vector: a malicious page can instruct the agent to call \`comet_upload {filePath: \"/Users/x/.ssh/id_rsa\"}\` and the file lands in the next form submission.

## Fix

Layered allowlist:

1. **Opt-in \`COMET_UPLOAD_ROOT\` env**: when set, resolve symlinks with \`realpathSync\` and require the canonical path to live under the configured root.
2. **Hardcoded denylist** (active when env unset, preserves existing permissive default): refuse uploads from \`~/.ssh\`, \`~/.aws\`, \`~/.config/{gh,gcloud}\`, \`~/.gnupg\`, \`~/.kube\`, \`~/.docker\`, \`~/Library/Keychains\`, \`/etc/shadow\`, \`/etc/sudoers\`, \`/root\`.
3. **Warning log** when env unset, so users notice they can tighten this.

Symlink resolution defeats \`~/uploads/sneak -> ~/.ssh/id_rsa\` style bypasses. \`statSync\` confirms it's a regular file.

Also tightened \`comet_tabs action=switch|close tabId=...\`: validate value matches \`/^[A-Fa-f0-9-]{16,64}$/\` before passing to \`Target.connect\` / \`Target.closeTarget\`. CDP target ids are 32-char hex; bogus values otherwise produce cryptic errors and can be coaxed into traversing the local CDP HTTP API surface (\`/json/version\`, …).

Removed dead \`connectionCheckInterval\` field on \`CometCDPClient\` — declared but never assigned/cleared.

## Compatibility

Default behaviour unchanged for any caller not uploading from a sensitive system path. The new env var is opt-in.

## Test plan

- [ ] \`npm run test:unit\` passes
- [ ] Manual: \`COMET_UPLOAD_ROOT=/tmp comet_upload filePath=/tmp/foo.png\` works
- [ ] Manual: \`COMET_UPLOAD_ROOT=/tmp comet_upload filePath=/etc/passwd\` rejected
- [ ] Manual: unset env + \`comet_upload filePath=~/.ssh/id_rsa\` rejected
- [ ] Manual: unset env + normal-path upload works with warning to stderr
- [ ] Adversarial: symlink \`~/uploads/x -> ~/.ssh/id_rsa\` rejected
- [ ] Manual: \`comet_tabs action=switch tabId=\"bogus\"\` returns validation error, not CDP error

🤖 Generated with [Claude Code](https://claude.com/claude-code)