### PR TITLE
fix(tabs): exclude sidecar URL when picking the main Perplexity tab

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -350,10 +350,15 @@ export class CometCDPClient {
       } catch { /* target gone */ }
     }
 
-    // Find best target
+    // Find best target. Prefer the MAIN Perplexity tab — explicitly
+    // exclude `sidecar` URLs, which Comet uses for its right-panel
+    // chat helper. Connecting to the sidecar by mistake silently
+    // routes `sendPrompt` / `stopAgent` to the wrong tab.
     const targets = await this.listTargets();
-    const target = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai')) ||
-                   targets.find(t => t.type === 'page' && t.url !== 'about:blank');
+    const target =
+      targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai') && !t.url.includes('sidecar')) ||
+      targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai')) ||
+      targets.find(t => t.type === 'page' && t.url !== 'about:blank');
 
     if (target) {
       return await this.connect(target.id);
@@ -405,7 +410,9 @@ export class CometCDPClient {
    */
   async ensureOnPerplexityTab(): Promise<boolean> {
     try {
-      // First check if current connection is valid and on Perplexity
+      // First check if current connection is valid and on Perplexity.
+      // Reject the sidecar URL — same reason as in reconnect(): the
+      // sidecar matches `perplexity.ai` but is a different tab.
       if (this.client) {
         try {
           const urlResult = await this.client.Runtime.evaluate({
@@ -413,8 +420,8 @@ export class CometCDPClient {
             timeout: 2000
           });
           const currentUrl = urlResult.result.value as string;
-          if (currentUrl?.includes('perplexity.ai')) {
-            return true; // Already on Perplexity tab
+          if (currentUrl?.includes('perplexity.ai') && !currentUrl.includes('sidecar')) {
+            return true; // Already on Perplexity main tab
           }
         } catch {
           // Current connection is stale, continue to reconnect
@@ -429,10 +436,10 @@ export class CometCDPClient {
         return true;
       }
 
-      // Fallback: find any Perplexity tab
+      // Fallback: find any Perplexity tab that isn't the sidecar.
       const targets = await this.listTargets();
       const perplexityTab = targets.find(t =>
-        t.type === 'page' && t.url.includes('perplexity.ai')
+        t.type === 'page' && t.url.includes('perplexity.ai') && !t.url.includes('sidecar')
       );
 
       if (perplexityTab) {
@@ -458,7 +465,10 @@ export class CometCDPClient {
         timeout: 2000
       });
       const url = result.result.value as string;
-      return url?.includes('perplexity.ai') || false;
+      // Sidecar URLs match `perplexity.ai` but are a different surface; treat
+      // them as "not the main tab" so callers don't dispatch sendPrompt /
+      // stopAgent there.
+      return !!url && url.includes('perplexity.ai') && !url.includes('sidecar');
     } catch {
       return false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,8 +136,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const targets = await cometClient.listTargets();
         const freshTargets = targets; // Use the same list, no cleanup
 
-        // Prefer connecting to existing Perplexity tab, or any page tab
-        const perplexityTab = freshTargets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'));
+        // Prefer connecting to the MAIN Perplexity tab (not the sidecar).
+        // Comet's right-panel chat helper lives at a sidecar URL that also
+        // matches `perplexity.ai` substring — connecting to it routes
+        // sendPrompt / stopAgent to the wrong tab.
+        const perplexityTab =
+          freshTargets.find(t => t.type === 'page' && t.url.includes('perplexity.ai') && !t.url.includes('sidecar')) ||
+          freshTargets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'));
         const anyPage = perplexityTab || freshTargets.find(t => t.type === 'page');
 
         if (anyPage) {
@@ -188,7 +193,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           try {
             await cometClient.startComet(9223);
             const targets = await cometClient.listTargets();
-            const page = targets.find(t => t.type === 'page');
+            // Prefer Perplexity main tab over the sidecar (see comet_connect
+            // for rationale). Fall back to any page tab if neither exists.
+            const page =
+              targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai') && !t.url.includes('sidecar')) ||
+              targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai')) ||
+              targets.find(t => t.type === 'page');
             if (page) await cometClient.connect(page.id);
           } catch {
             return { content: [{ type: "text", text: "Error: Failed to establish connection to Comet browser" }] };


### PR DESCRIPTION
## Summary

Comet renders its right-panel chat helper at a URL that also matches the \`perplexity.ai\` substring (e.g. \`perplexity.ai/.../sidecar\`). Five sites in the codebase pick \"any tab whose URL contains \`perplexity.ai\`\" without excluding the sidecar:

- \`reconnect()\` fresh-start fallback — after a reconnect, sendPrompt / stopAgent route to the wrong tab.
- \`ensureOnPerplexityTab()\` initial current-URL check — returns \`true\` when on the sidecar.
- \`ensureOnPerplexityTab()\` last-resort \"any Perplexity tab\" fallback — picks the sidecar if \`listTabsCategorized().main\` is null.
- \`isOnPerplexityTab()\` predicate — callers checking this before dispatching prompts silently send to the sidecar.
- \`comet_connect\` initial target picker + \`comet_ask\` recovery path — first-time connection lands on the sidecar.

## Fix

\`listTabsCategorized()\` already encodes the right filter (\`!t.url.includes('sidecar')\`); we just weren't applying it consistently. Each affected site now does the same exclusion, with a secondary fallback to \"any perplexity.ai tab\" if literally no main tab exists.

## Compatibility

No public API change. Default user with one main tab + sidecar gets the main tab from now on, instead of whichever appeared first in the CDP target list (often the sidecar after a recent agent run).

## Test plan

- [ ] \`npm run test:unit\` passes
- [ ] Manual: open Comet sidecar then run \`comet_connect\` — connects to main tab, not sidecar
- [ ] Manual: \`comet_ask\` after a forced reconnect targets the main tab
- [ ] Manual: \`comet_poll\` returns status from main tab, not sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)