### PR TITLE
fix(cdp): coalesce concurrent reconnects, fix flapping breaker, plug load-event listener leak

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -155,7 +155,17 @@ export class CometCDPClient {
   private lastTargetId: string | undefined;
   private reconnectAttempts: number = 0;
   private maxReconnectAttempts: number = 10;
-  private isReconnecting: boolean = false;
+  // In-flight reconnect promise. Multiple concurrent operations entering
+  // `withAutoReconnect` after a transport drop must NOT each kick off
+  // their own reconnect — they would race on `this.client` (one closes
+  // while another is mid-handshake), corrupting state. We cache the
+  // single promise and let all waiters await it.
+  private reconnectPromise: Promise<void> | null = null;
+  // Consecutive successful operations since the last connection error.
+  // Used to reset the attempt counter only after the connection has
+  // proven stable, so a flapping link doesn't silently bypass the
+  // max-attempts breaker.
+  private consecutiveSuccesses: number = 0;
   private connectionCheckInterval: NodeJS.Timeout | null = null;
   private lastHealthCheck: number = 0;
   private healthCheckCache: boolean = false;
@@ -244,14 +254,34 @@ export class CometCDPClient {
   /**
    * Auto-reconnect wrapper for operations with exponential backoff
    */
+  /**
+   * Coalesce concurrent reconnect attempts onto a single promise.
+   * Any caller awaiting `ensureSingleReconnect()` either receives the
+   * promise of an already-running reconnect or starts a fresh one.
+   */
+  private ensureSingleReconnect(): Promise<void> {
+    if (!this.reconnectPromise) {
+      const attempt = this.reconnectAttempts;
+      const delay = Math.min(300 * Math.pow(1.3, Math.max(attempt - 1, 0)), 2000);
+      this.reconnectPromise = (async () => {
+        this.invalidateHealthCache();
+        await new Promise(r => setTimeout(r, delay));
+        await this.reconnect();
+      })().finally(() => {
+        this.reconnectPromise = null;
+      });
+    }
+    return this.reconnectPromise;
+  }
+
+  /**
+   * Auto-reconnect wrapper for operations with exponential backoff
+   */
   async withAutoReconnect<T>(operation: () => Promise<T>): Promise<T> {
-    // Wait for ongoing reconnect
-    if (this.isReconnecting) {
-      let waitCount = 0;
-      while (this.isReconnecting && waitCount < 20) {
-        await new Promise(resolve => setTimeout(resolve, 300));
-        waitCount++;
-      }
+    // If a reconnect is already in-flight, wait for it instead of
+    // launching a parallel one.
+    if (this.reconnectPromise) {
+      try { await this.reconnectPromise; } catch { /* fall through to retry */ }
     }
 
     // Pre-operation health check (uses cache for efficiency)
@@ -263,16 +293,23 @@ export class CometCDPClient {
 
     try {
       const result = await operation();
-      this.reconnectAttempts = 0;
+      // Reset attempt counter only after a window of consecutive
+      // successes — a flapping connection that succeeds every Nth try
+      // must not be able to silently bypass the breaker.
+      this.consecutiveSuccesses++;
+      if (this.consecutiveSuccesses >= 3) {
+        this.reconnectAttempts = 0;
+      }
       return result;
     } catch (error: unknown) {
+      this.consecutiveSuccesses = 0;
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       const connectionErrors = [
         'WebSocket', 'CLOSED', 'not open', 'disconnected', 'readyState',
         'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE', 'socket hang up',
         'Protocol error', 'Target closed', 'Session closed', 'Execution context',
-        'not found', 'detached', 'crashed', 'Inspected target navigated', 'aborted'
+        'detached', 'crashed', 'Inspected target navigated', 'aborted'
       ];
 
       const isConnectionError = connectionErrors.some(e =>
@@ -281,26 +318,22 @@ export class CometCDPClient {
 
       if (isConnectionError && this.reconnectAttempts < this.maxReconnectAttempts) {
         this.reconnectAttempts++;
-        this.isReconnecting = true;
-        this.invalidateHealthCache();
 
         try {
-          // Shorter delays for faster recovery
-          const delay = Math.min(300 * Math.pow(1.3, this.reconnectAttempts - 1), 2000);
-          await new Promise(resolve => setTimeout(resolve, delay));
-          await this.reconnect();
-          this.isReconnecting = false;
-          // Retry the operation after reconnect
+          // Coalesce: shared promise across all concurrent callers
+          await this.ensureSingleReconnect();
           return await operation();
         } catch (reconnectError) {
-          this.isReconnecting = false;
           // If reconnect fails, try fresh start
           if (this.reconnectAttempts < this.maxReconnectAttempts) {
             try {
               await this.startComet(this.state.port);
               await new Promise(r => setTimeout(r, 1500));
               const targets = await this.listTargets();
-              const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity'));
+              // Pick main Perplexity tab, NOT the sidecar.
+              const page =
+                targets.find(t => t.type === 'page' && t.url.includes('perplexity') && !t.url.includes('sidecar')) ||
+                targets.find(t => t.type === 'page' && t.url.includes('perplexity'));
               const anyPage = page || targets.find(t => t.type === 'page');
               if (anyPage) {
                 await this.connect(anyPage.id);
@@ -1078,11 +1111,25 @@ export class CometCDPClient {
             throw new Error(result.errorText);
           }
 
-          // Wait for load with timeout
-          await Promise.race([
-            this.client!.Page.loadEventFired(),
-            new Promise((_, reject) => setTimeout(() => reject(new Error('Page load timeout')), 15000))
-          ]);
+          // Wait for load with timeout.
+          // `client.Page.loadEventFired()` resolves on the next event but
+          // leaves the underlying listener registered if the timeout
+          // branch of Promise.race wins. After many timeouts in one
+          // session the listener list grows unbounded. Subscribe via
+          // `client.once` (which auto-unsubscribes after one event) and
+          // explicitly remove the listener when the timeout wins.
+          const client = this.client!;
+          await new Promise<void>((resolve, reject) => {
+            const onLoad = () => {
+              clearTimeout(timer);
+              resolve();
+            };
+            const timer = setTimeout(() => {
+              client.removeListener('Page.loadEventFired', onLoad);
+              reject(new Error('Page load timeout'));
+            }, 15000);
+            client.once('Page.loadEventFired', onLoad);
+          });
 
           this.state.currentUrl = url;
         });


### PR DESCRIPTION
## Summary

Three independent reliability fixes around the auto-reconnect path.

### 1. Reconnect race

\`withAutoReconnect\` used an \`isReconnecting\` boolean and busy-waited on it. Two concurrent operations entering the catch branch at the same time (very real during the \`comet_ask\` polling loop where a \`safeEvaluate\` may be in flight while \`extractAgentStatus\` is also evaluating) **both** observe the flag as false, **both** increment the counter, **both** set it, **both** call \`this.reconnect()\` — which closes and reopens \`this.client\`. The second close races with the first connect, corrupting state and producing cascading \`not open / readyState\` errors that re-enter the same path.

Replaced with a single in-flight \`reconnectPromise\` cache. New callers that find a pending promise simply \`await\` it; only the first caller actually starts a reconnect. The promise is cleared in \`.finally()\` so the next genuine failure restarts the cycle.

### 2. Flapping breaker

\`reconnectAttempts\` was reset to 0 on every successful operation. A flapping connection that succeeds every Nth try would silently never trip \`maxReconnectAttempts\`, hiding a degraded transport. Counter now resets only after **3 consecutive** successes.

### 3. Page.loadEventFired listener leak

\`navigateWithRetry\` did \`Promise.race([loadEventFired(), timeout])\`. When the timeout wins, the underlying \`Page.loadEventFired\` listener stays registered. Over a long session with repeated timeouts, listeners accumulate (eventually a \`MaxListenersExceededWarning\` from EventEmitter).

Replaced with \`client.once('Page.loadEventFired', onLoad)\` plus an explicit \`removeListener\` on the timeout branch, so the listener is always removed exactly once.

### Bonus cleanups

- Removed \`'not found'\` from the connection-error substring list — it falsely matched the legitimate \`Error('No file input found...')\` thrown by upload code, triggering unnecessary reconnects on normal application errors.
- Fresh-start fallback inside \`withAutoReconnect\` now excludes the sidecar URL when picking a target tab (matches the rationale in the companion sidecar-filter PR).

## Compatibility

Public API unchanged. Internal state (`isReconnecting` boolean) is replaced by `reconnectPromise` — no consumers reach into private state.

## Test plan

- [ ] \`npm run test:unit\` passes
- [ ] Manual: forced disconnect during a polling \`comet_ask\` recovers cleanly without cascading errors
- [ ] Manual: \`navigateWithRetry\` to a slow URL eventually succeeds without \`MaxListenersExceededWarning\`
- [ ] Manual: a flapping connection (succeed/fail alternating) eventually trips the breaker instead of looping forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)