### PR TITLE
fix(cdp-client): type-only emitter cast for Page.loadEventFired race

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -1383,9 +1383,19 @@ export class CometCDPClient {
           // leaves the underlying listener registered if the timeout
           // branch of Promise.race wins. After many timeouts in one
           // session the listener list grows unbounded. Subscribe via
-          // `client.once` (which auto-unsubscribes after one event) and
+          // `once` (which auto-unsubscribes after one event) and
           // explicitly remove the listener when the timeout wins.
-          const client = this.client!;
+          //
+          // The CRI Client is an EventEmitter at runtime, but the type
+          // declaration in @types/chrome-remote-interface only exposes
+          // `on(...)` — not `once`/`removeListener`. Cast to a minimal
+          // EventEmitter-shaped surface so this compiles without
+          // pulling in `events` as a value import for a type-only need.
+          interface CdpEmitter {
+            once(event: string, listener: (...args: unknown[]) => void): void;
+            removeListener(event: string, listener: (...args: unknown[]) => void): void;
+          }
+          const client = this.client! as unknown as CdpEmitter;
           await new Promise<void>((resolve, reject) => {
             const onLoad = () => {
               clearTimeout(timer);


### PR DESCRIPTION
## Summary

Main currently fails `tsc` with:

\`\`\`
src/cdp-client.ts(1394,22): error TS2339: Property 'removeListener' does not exist on type 'Client'.
src/cdp-client.ts(1397,20): error TS2339: Property 'once' does not exist on type 'Client'.
\`\`\`

Introduced by #18 (`ebf055e`). The CRI \`Client\` is an EventEmitter at runtime, but \`@types/chrome-remote-interface\` only declares \`on(...)\` — not \`once\`/\`removeListener\`. Build fails on every PR until this lands.

## Fix

Locally-scoped EventEmitter-shaped interface + a single `as unknown as ...` cast. No runtime change.

## Why it matters

CI is red on main, which means every open PR (#14, #15, #17, #20) is also red regardless of its own correctness. This unblocks all four.

## Test plan

- [x] `npm run test:unit` (55/55 pass locally)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)