### PR TITLE
fix: exit the process when the stdio transport closes (stop orphaned server processes)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -798,4 +798,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 const transport = new StdioServerTransport();
+
+// A stdio MCP server's lifetime is its client pipe. When the client disconnects
+// (or stdin ends), exit so we don't leak an orphaned, idle process holding a CDP
+// connection. Without this, sessions/stalls accumulate zombie processes.
+let exiting = false;
+const shutdown = (code = 0): void => {
+  if (exiting) return; // idempotent: onclose + stdin close may both fire
+  exiting = true;
+  try {
+    transport.close?.();
+  } catch {
+    // ignore
+  }
+  process.exit(code);
+};
+transport.onclose = () => shutdown(0);
+transport.onerror = (err: unknown) => {
+  console.error(
+    "[comet] transport error:",
+    err instanceof Error ? err.message : err,
+  );
+  shutdown(1);
+};
+// stdin end/close means the client pipe is gone; for a long-lived stdio MCP
+// client this is a disconnect, so we exit. (A client that half-closes stdin
+// while still reading stdout is not the MCP usage pattern here.)
+process.stdin.on("end", () => shutdown(0));
+process.stdin.on("close", () => shutdown(0));
+
 server.connect(transport);


### PR DESCRIPTION
### Problem
The server connects the stdio transport with no close/error handling:

```ts
const transport = new StdioServerTransport();
server.connect(transport);
```

When the MCP **client** disconnects — the session ends, or a long `comet_ask` browser-modal stall trips the client's timeout and it tears down the pipe — the stdio channel closes, but **the Node process does not exit**. It keeps running, orphaned and idle, holding a CDP connection to Comet.

In practice these accumulate fast: on one machine, **7 → 34 orphaned `perplexity-comet-mcp` processes were observed over three days**, monotonically increasing, one per session/stall. They are never reaped, and the pileup correlates with mid-session connection drops (handle pressure).

### Root cause
A stdio MCP server's lifetime is bound to its stdin/stdout pipe to the client. When the client closes that pipe, the server should exit. `StdioServerTransport` exposes `onclose`/`onerror`; this server wires neither, so a closed pipe is silently ignored and the event loop stays alive.

### Fix
Exit on transport close/error and on stdin end/close, with an idempotent guard:

```ts
let exiting = false;
const shutdown = (code = 0): void => {
  if (exiting) return;
  exiting = true;
  try { transport.close?.(); } catch { /* ignore */ }
  process.exit(code);
};
transport.onclose = () => shutdown(0);
transport.onerror = (err: unknown) => { console.error("[comet] transport error:", err instanceof Error ? err.message : err); shutdown(1); };
process.stdin.on("end", () => shutdown(0));
process.stdin.on("close", () => shutdown(0));
```

### Notes
- Pure lifecycle: no change to any tool behavior, prompt handling, or CDP logic.
- If a tool call is in flight when the client disconnects, that work is abandoned on exit — correct, since there is no client to return the result to.
- `tsc` is clean on this file. The two pre-existing `cdp-client.ts` type errors are unrelated and already present on upstream `main`.

### Out of scope (happy to file separately)
The stalls themselves are triggered by `comet_ask` auto-rewriting prompts containing words like `visit/open/browse/page/.ai` into a "use your browser" form, which surfaces Perplexity's browser-control modal. This PR only stops the *orphaned-process* consequence so a stall can't leak a zombie.