### PR TITLE
fix(security): address upload path validation vulnerabilities from PR #14 review

### DIFF
--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -5,6 +5,7 @@ import CDP from "chrome-remote-interface";
 import { spawn, ChildProcess, execSync } from "child_process";
 import { platform } from "os";
 import { existsSync } from "fs";
+import { validateUploadPath } from "./upload-validator.js";
 import type {
   CDPTarget,
   CDPVersion,
@@ -1579,6 +1580,21 @@ export class CometCDPClient {
     return this.withAutoReconnect(async () => {
       this.ensureConnected();
 
+      // Validate and resolve the path before touching the DOM.
+      // This enforces COMET_UPLOAD_ROOT allowlist (if set) and the sensitive-
+      // path denylist at the CDP layer so every caller is protected, not just
+      // the MCP tool handler in index.ts.
+      let resolvedPath: string;
+      try {
+        resolvedPath = validateUploadPath(filePath);
+      } catch (err: unknown) {
+        return {
+          success: false,
+          message: err instanceof Error ? err.message : String(err),
+          inputFound: false,
+        };
+      }
+
       // Find the file input element
       let nodeId: number;
 
@@ -1637,11 +1653,11 @@ export class CometCDPClient {
         }
       }
 
-      // Set the file on the input element
+      // Set the file on the input element using the validated canonical path.
       try {
         await this.client!.DOM.setFileInputFiles({
           nodeId: nodeId!,
-          files: [filePath]
+          files: [resolvedPath]
         });
 
         // Trigger change event to notify the page
@@ -1660,7 +1676,7 @@ export class CometCDPClient {
 
         return {
           success: true,
-          message: `File uploaded successfully: ${filePath}`,
+          message: `File uploaded successfully: ${resolvedPath}`,
           inputFound: true
         };
       } catch (error: any) {
@@ -1683,6 +1699,19 @@ export class CometCDPClient {
     return this.withAutoReconnect(async () => {
       this.ensureConnected();
 
+      // Validate all paths before touching the DOM.
+      const resolvedPaths: string[] = [];
+      for (const fp of filePaths) {
+        try {
+          resolvedPaths.push(validateUploadPath(fp));
+        } catch (err: unknown) {
+          return {
+            success: false,
+            message: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+
       const doc = await this.client!.DOM.getDocument();
       const sel = selector || 'input[type="file"]';
 
@@ -1701,7 +1730,7 @@ export class CometCDPClient {
       try {
         await this.client!.DOM.setFileInputFiles({
           nodeId: result.nodeId,
-          files: filePaths
+          files: resolvedPaths
         });
 
         // Trigger change event

--- a/src/http-bridge.ts
+++ b/src/http-bridge.ts
@@ -1,0 +1,845 @@
+#!/usr/bin/env node
+
+/**
+ * HTTP Bridge Server for Remote MCP Access
+ *
+ * Enables remote clients (e.g., n8n on Linux) to connect to a Comet instance
+ * running on Windows/macOS over HTTP.
+ *
+ * Usage:
+ *   COMET_BRIDGE_TOKEN=your-secret-token node dist/http-bridge.js
+ *
+ * Environment variables:
+ *   - COMET_BRIDGE_TOKEN:       Required. Authentication token for API access.
+ *   - COMET_BRIDGE_PORT:        Optional. Port to listen on (default: 3210).
+ *   - COMET_BRIDGE_HOST:        Optional. Host to bind to (default: 0.0.0.0).
+ *   - COMET_BRIDGE_CORS_ORIGIN: Optional. Allowed CORS origin. Omit to disable
+ *                               CORS headers (recommended for server-to-server
+ *                               use). Set to a specific origin (e.g.,
+ *                               "https://n8n.example.com") for browser clients.
+ *                               Never set to "*" in production.
+ */
+
+import http from "http";
+import { timingSafeEqual } from "crypto";
+import { URL } from "url";
+import { cometClient } from "./cdp-client.js";
+import { cometAI } from "./comet-ai.js";
+import { validateUploadPath, validateTabId } from "./upload-validator.js";
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const BRIDGE_TOKEN = process.env.COMET_BRIDGE_TOKEN;
+const BRIDGE_PORT = parseInt(process.env.COMET_BRIDGE_PORT || "3210", 10);
+const BRIDGE_HOST = process.env.COMET_BRIDGE_HOST || "0.0.0.0";
+
+/**
+ * CORS origin to include in responses, or null to omit CORS headers.
+ *
+ * Wildcard CORS ("*") is intentionally not supported: the bridge uses
+ * bearer-token authentication, and "Access-Control-Allow-Origin: *" would
+ * let any origin trigger credentialed cross-site requests in a browser.
+ * Set COMET_BRIDGE_CORS_ORIGIN to a specific trusted origin when a browser-
+ * based client needs access.
+ */
+const CORS_ORIGIN = process.env.COMET_BRIDGE_CORS_ORIGIN ?? null;
+
+if (!BRIDGE_TOKEN) {
+  console.error("ERROR: COMET_BRIDGE_TOKEN environment variable is required");
+  console.error("Usage: COMET_BRIDGE_TOKEN=your-secret-token node dist/http-bridge.js");
+  process.exit(1);
+}
+
+// ============================================================================
+// Session State (same as index.ts)
+// ============================================================================
+
+interface SessionState {
+  currentTaskId: string | null;
+  taskStartTime: number | null;
+  lastPrompt: string | null;
+  lastResponse: string | null;
+  lastResponseTime: number | null;
+  steps: string[];
+  isActive: boolean;
+}
+
+const sessionState: SessionState = {
+  currentTaskId: null,
+  taskStartTime: null,
+  lastPrompt: null,
+  lastResponse: null,
+  lastResponseTime: null,
+  steps: [],
+  isActive: false,
+};
+
+function generateTaskId(): string {
+  return `task_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+}
+
+function startNewTask(prompt: string): string {
+  const taskId = generateTaskId();
+  sessionState.currentTaskId = taskId;
+  sessionState.taskStartTime = Date.now();
+  sessionState.lastPrompt = prompt;
+  sessionState.lastResponse = null;
+  sessionState.lastResponseTime = null;
+  sessionState.steps = [];
+  sessionState.isActive = true;
+  cometAI.resetStabilityTracking();
+  return taskId;
+}
+
+function completeTask(response: string): void {
+  sessionState.lastResponse = response;
+  sessionState.lastResponseTime = Date.now();
+  sessionState.isActive = false;
+}
+
+function isSessionStale(): boolean {
+  if (!sessionState.taskStartTime) return true;
+  return Date.now() - sessionState.taskStartTime > 5 * 60 * 1000;
+}
+
+// ============================================================================
+// Tool Handlers (extracted from index.ts for reuse)
+// ============================================================================
+
+type ToolResult = {
+  success: boolean;
+  content: string | { type: string; data?: string; mimeType?: string }[];
+  error?: string;
+};
+
+async function handleConnect(): Promise<ToolResult> {
+  const startResult = await cometClient.startComet(9223);
+  const targets = await cometClient.listTargets();
+  const perplexityTab = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'));
+  const anyPage = perplexityTab || targets.find(t => t.type === 'page');
+
+  if (anyPage) {
+    await cometClient.connect(anyPage.id);
+    if (!anyPage.url.includes('perplexity.ai')) {
+      await cometClient.navigate("https://www.perplexity.ai/", true);
+      await new Promise(resolve => setTimeout(resolve, 1500));
+    }
+    return { success: true, content: `${startResult}\nConnected to Perplexity` };
+  }
+
+  const newTab = await cometClient.newTab("https://www.perplexity.ai/");
+  await new Promise(resolve => setTimeout(resolve, 2000));
+  await cometClient.connect(newTab.id);
+  return { success: true, content: `${startResult}\nCreated new tab and navigated to Perplexity` };
+}
+
+async function handleAsk(args: {
+  prompt: string;
+  context?: string;
+  newChat?: boolean;
+  timeout?: number;
+}): Promise<ToolResult> {
+  let prompt = args.prompt;
+  const context = args.context;
+  const maxTimeout = args.timeout || 120000;
+  const newChat = args.newChat || false;
+
+  if (!prompt || prompt.trim().length === 0) {
+    return { success: false, content: "", error: "prompt cannot be empty" };
+  }
+
+  // Prepend context if provided
+  if (context && context.trim().length > 0) {
+    const contextPrefix = `Context for this task:\n\`\`\`\n${context.trim()}\n\`\`\`\n\nBased on the above context, `;
+    prompt = contextPrefix + prompt;
+  }
+
+  const taskId = startNewTask(prompt);
+  void taskId; // used for session state side-effects
+
+  // Pre-operation check
+  try {
+    await cometClient.preOperationCheck();
+  } catch {
+    try {
+      await cometClient.startComet(9223);
+      const targets = await cometClient.listTargets();
+      const page = targets.find(t => t.type === 'page');
+      if (page) await cometClient.connect(page.id);
+    } catch {
+      return { success: false, content: "", error: "Failed to establish connection to Comet browser" };
+    }
+  }
+
+  // Normalize prompt
+  prompt = prompt
+    .replace(/^[-*•]\s*/gm, '')
+    .replace(/\n+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Transform for agentic browsing
+  const hasUrl = /https?:\/\/[^\s]+/.test(prompt);
+  const hasWebsiteRef = /\b(go to|visit|navigate|open|browse|check|look at|read from|click|fill|submit|login|sign in|download from)\b/i.test(prompt);
+  const hasSiteNames = /\b(\.com|\.org|\.io|\.net|\.ai|website|webpage|page|site)\b/i.test(prompt);
+  const needsAgenticBrowsing = hasUrl || hasWebsiteRef || hasSiteNames;
+
+  if (needsAgenticBrowsing) {
+    const alreadyAgentic = /^(use your browser|using your browser|open a browser|navigate to|browse to)/i.test(prompt);
+    if (!alreadyAgentic) {
+      if (hasUrl) {
+        const urlMatch = prompt.match(/https?:\/\/[^\s]+/);
+        if (urlMatch) {
+          const url = urlMatch[0];
+          const restOfPrompt = prompt.replace(url, '').trim();
+          prompt = `Use your browser to navigate to ${url} and ${restOfPrompt || 'tell me what you find there'}`;
+        }
+      } else {
+        prompt = `Use your browser to ${prompt.toLowerCase().startsWith('go') ? '' : 'go and '}${prompt}`;
+      }
+    }
+  }
+
+  // Handle newChat navigation
+  if (newChat) {
+    await cometClient.ensureConnection();
+    try {
+      await cometClient.navigate("https://www.perplexity.ai/", true);
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    } catch {
+      const targets = await cometClient.listTargets();
+      const mainTab = targets.find(t => t.type === 'page' && t.url.includes('perplexity'));
+      if (mainTab) {
+        await cometClient.connect(mainTab.id);
+      } else {
+        const anyPage = targets.find(t => t.type === 'page');
+        if (anyPage) {
+          await cometClient.connect(anyPage.id);
+          await cometClient.navigate("https://www.perplexity.ai/", true);
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, 1500));
+    }
+  } else {
+    const tabs = await cometClient.listTabsCategorized();
+    if (tabs.main) {
+      await cometClient.connect(tabs.main.id);
+    }
+
+    const urlResult = await cometClient.evaluate('window.location.href');
+    const currentUrl = urlResult.result.value as string;
+    if (!currentUrl?.includes('perplexity.ai')) {
+      await cometClient.navigate("https://www.perplexity.ai/", true);
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  }
+
+  cometAI.resetStabilityTracking();
+
+  // Capture old state
+  const oldStateResult = await cometClient.evaluate(`
+    (() => {
+      const proseEls = document.querySelectorAll('[class*="prose"]');
+      const lastProse = proseEls[proseEls.length - 1];
+      return {
+        count: proseEls.length,
+        lastText: lastProse ? lastProse.innerText.substring(0, 100) : ''
+      };
+    })()
+  `);
+  const oldState = oldStateResult.result.value as { count: number; lastText: string };
+
+  // Send prompt
+  await cometAI.sendPrompt(prompt);
+
+  // Smart polling
+  const startTime = Date.now();
+  const stepsCollected: string[] = [];
+  let sawNewResponse = false;
+  let lastActivityTime = Date.now();
+  let previousResponse = '';
+  const POLL_INTERVAL = 1500;
+  const IDLE_TIMEOUT = 6000;
+  let consecutiveErrors = 0;
+  const MAX_CONSECUTIVE_ERRORS = 5;
+
+  while (Date.now() - startTime < maxTimeout) {
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
+
+    try {
+      const isOnPerplexity = await cometClient.isOnPerplexityTab();
+      if (!isOnPerplexity) {
+        const switched = await cometClient.ensureOnPerplexityTab();
+        if (!switched) {
+          consecutiveErrors++;
+          continue;
+        }
+      }
+
+      const currentStateResult = await cometClient.withAutoReconnect(async () => {
+        return await cometClient.evaluate(`
+          (() => {
+            const proseEls = document.querySelectorAll('[class*="prose"]');
+            const lastProse = proseEls[proseEls.length - 1];
+            return {
+              count: proseEls.length,
+              lastText: lastProse ? lastProse.innerText.substring(0, 100) : ''
+            };
+          })()
+        `);
+      });
+      const currentState = currentStateResult.result.value as { count: number; lastText: string };
+
+      if (!sawNewResponse) {
+        if (currentState.count > oldState.count ||
+            (currentState.lastText && currentState.lastText !== oldState.lastText)) {
+          sawNewResponse = true;
+        }
+      }
+
+      const status = await cometAI.getAgentStatus();
+      consecutiveErrors = 0;
+
+      if (status.response !== previousResponse) {
+        lastActivityTime = Date.now();
+        previousResponse = status.response;
+      }
+
+      for (const step of status.steps) {
+        if (!stepsCollected.includes(step)) {
+          stepsCollected.push(step);
+          lastActivityTime = Date.now();
+        }
+      }
+
+      sessionState.steps = stepsCollected;
+
+      if (status.status === 'completed' && sawNewResponse) {
+        const response = status.response;
+        completeTask(response);
+        return { success: true, content: response };
+      }
+
+      if (sawNewResponse && Date.now() - lastActivityTime > IDLE_TIMEOUT) {
+        const response = status.response || previousResponse;
+        completeTask(response);
+        return { success: true, content: response };
+      }
+    } catch {
+      consecutiveErrors++;
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        break;
+      }
+    }
+  }
+
+  const finalResponse = sessionState.lastResponse || previousResponse || "Task timed out or no response received";
+  completeTask(finalResponse);
+  return { success: true, content: finalResponse };
+}
+
+async function handlePoll(): Promise<ToolResult> {
+  if (isSessionStale()) {
+    return { success: true, content: "No active task (session stale or not started)" };
+  }
+
+  const status = await cometAI.getAgentStatus();
+  const allSteps = [...new Set([...sessionState.steps, ...status.steps])];
+
+  let output = '';
+  if (sessionState.isActive) {
+    output = `Status: working\nPrompt: ${sessionState.lastPrompt || 'unknown'}\n`;
+    if (status.response) {
+      output += `\nPartial response:\n${status.response.substring(0, 500)}${status.response.length > 500 ? '...' : ''}`;
+    }
+  } else {
+    output = `Status: complete\nResponse:\n${sessionState.lastResponse || 'No response'}`;
+  }
+
+  if (allSteps.length > 0) {
+    output += `\nSteps:\n${allSteps.map(s => `  • ${s}`).join('\n')}\n`;
+  }
+  if (status.status === 'working' || sessionState.isActive) {
+    output += `\n[Use comet_stop to interrupt, or comet_screenshot to see current page]`;
+  }
+
+  return { success: true, content: output };
+}
+
+async function handleStop(): Promise<ToolResult> {
+  const stopped = await cometAI.stopAgent();
+  if (stopped) {
+    sessionState.isActive = false;
+  }
+  return { success: true, content: stopped ? "Agent stopped" : "No active agent to stop" };
+}
+
+async function handleScreenshot(): Promise<ToolResult> {
+  const result = await cometClient.screenshot("png");
+  return {
+    success: true,
+    content: [{ type: "image", data: result.data, mimeType: "image/png" }]
+  };
+}
+
+async function handleTabs(args: { action?: string; domain?: string; tabId?: string }): Promise<ToolResult> {
+  const action = args.action || 'list';
+  const domain = args.domain;
+  const rawTabId = args.tabId;
+
+  switch (action) {
+    case 'list': {
+      const summary = await cometClient.getTabSummary();
+      return { success: true, content: summary };
+    }
+
+    case 'switch': {
+      if (rawTabId) {
+        // Validate tabId before passing to CDP.
+        try {
+          const tabId = validateTabId(rawTabId);
+          await cometClient.connect(tabId);
+          return { success: true, content: `Switched to tab: ${tabId}` };
+        } catch (err: unknown) {
+          return { success: false, content: "", error: err instanceof Error ? err.message : String(err) };
+        }
+      }
+      if (domain) {
+        const tab = await cometClient.findTabByDomain(domain);
+        if (tab) {
+          await cometClient.connect(tab.id);
+          return { success: true, content: `Switched to ${tab.domain} (${tab.url})` };
+        }
+        return { success: false, content: "", error: `No tab found for domain: ${domain}` };
+      }
+      return { success: false, content: "", error: "Specify domain or tabId to switch" };
+    }
+
+    case 'close': {
+      const allTabs = await cometClient.getTabContexts();
+      if (allTabs.length <= 1) {
+        return { success: false, content: "", error: "Cannot close - this is the only browsing tab" };
+      }
+
+      if (rawTabId) {
+        // Validate tabId before passing to CDP.
+        try {
+          const tabId = validateTabId(rawTabId);
+          const success = await cometClient.closeTab(tabId);
+          return { success, content: success ? `Closed tab: ${tabId}` : "Failed to close tab" };
+        } catch (err: unknown) {
+          return { success: false, content: "", error: err instanceof Error ? err.message : String(err) };
+        }
+      }
+      if (domain) {
+        const tab = await cometClient.findTabByDomain(domain);
+        if (tab && tab.purpose !== 'main') {
+          const success = await cometClient.closeTab(tab.id);
+          return { success, content: success ? `Closed ${tab.domain}` : "Failed to close tab" };
+        }
+        if (tab?.purpose === 'main') {
+          return { success: false, content: "", error: "Cannot close main Perplexity tab" };
+        }
+        return { success: false, content: "", error: `No tab found for domain: ${domain}` };
+      }
+      return { success: false, content: "", error: "Specify domain or tabId to close" };
+    }
+
+    default:
+      return { success: false, content: "", error: `Unknown action: ${action}. Use: list, switch, close` };
+  }
+}
+
+async function handleUpload(args: { filePath?: string; selector?: string; checkOnly?: boolean }): Promise<ToolResult> {
+  const filePath = args.filePath;
+  if (!filePath) {
+    return { success: false, content: "", error: "filePath is required" };
+  }
+
+  // Validate path before any DOM interaction.
+  let resolvedPath: string;
+  try {
+    resolvedPath = validateUploadPath(filePath);
+  } catch (err: unknown) {
+    return { success: false, content: "", error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (args.checkOnly) {
+    const inputInfo = await cometClient.hasFileInput();
+    if (inputInfo.found) {
+      let msg = `Found ${inputInfo.count} file input(s) on the page:\n`;
+      msg += inputInfo.selectors.map((s: string, i: number) => `  ${i + 1}. ${s}`).join('\n');
+      msg += `\n\nUse comet_upload with filePath to upload to one of these inputs.`;
+      return { success: true, content: msg };
+    } else {
+      return { success: true, content: "No file input elements found on the current page." };
+    }
+  }
+
+  const result = await cometClient.uploadFile(resolvedPath, args.selector);
+  return {
+    success: result.success,
+    content: result.message,
+    error: result.success ? undefined : result.message,
+  };
+}
+
+async function handleMode(args: { mode?: string }): Promise<ToolResult> {
+  const mode = args.mode;
+
+  if (!mode) {
+    const result = await cometClient.evaluate(`
+      (() => {
+        const modes = ['Search', 'Research', 'Labs', 'Learn'];
+        for (const mode of modes) {
+          const btn = document.querySelector('button[aria-label="' + mode + '"]');
+          if (btn && btn.getAttribute('data-state') === 'checked') {
+            return mode.toLowerCase();
+          }
+        }
+        const dropdownBtn = document.querySelector('button[class*="gap"]');
+        if (dropdownBtn) {
+          const text = (dropdownBtn as HTMLElement).innerText.toLowerCase();
+          if (text.includes('search')) return 'search';
+          if (text.includes('research')) return 'research';
+          if (text.includes('labs')) return 'labs';
+          if (text.includes('learn')) return 'learn';
+        }
+        return 'search';
+      })()
+    `);
+
+    const currentMode = result.result.value as string;
+    const descriptions: Record<string, string> = {
+      search: 'Basic web search',
+      research: 'Deep research with comprehensive analysis',
+      labs: 'Analytics, visualizations, and coding',
+      learn: 'Educational content and explanations'
+    };
+
+    let output = `Current mode: ${currentMode}\n\nAvailable modes:\n`;
+    for (const [m, desc] of Object.entries(descriptions)) {
+      const marker = m === currentMode ? "→" : " ";
+      output += `${marker} ${m}: ${desc}\n`;
+    }
+
+    return { success: true, content: output };
+  }
+
+  const modeMap: Record<string, string> = {
+    search: "Search",
+    research: "Research",
+    labs: "Labs",
+    learn: "Learn",
+  };
+  const ariaLabel = modeMap[mode];
+  if (!ariaLabel) {
+    return { success: false, content: "", error: `Invalid mode: ${mode}. Use: search, research, labs, learn` };
+  }
+
+  const state = cometClient.currentState;
+  if (!state.currentUrl?.includes("perplexity.ai")) {
+    await cometClient.navigate("https://www.perplexity.ai/", true);
+  }
+
+  const clickResult = await cometClient.evaluate(`
+    (() => {
+      const btn = document.querySelector('button[aria-label="${ariaLabel}"]');
+      if (btn) {
+        btn.click();
+        return { success: true, method: 'button' };
+      }
+      const allButtons = document.querySelectorAll('button');
+      for (const b of allButtons) {
+        const text = b.innerText.toLowerCase();
+        if ((text.includes('search') || text.includes('research') ||
+             text.includes('labs') || text.includes('learn')) &&
+            b.querySelector('svg')) {
+          b.click();
+          return { success: true, method: 'dropdown-open', needsSelect: true };
+        }
+      }
+      return { success: false, error: "Mode selector not found" };
+    })()
+  `);
+
+  const result = clickResult.result.value as { success: boolean; method?: string; needsSelect?: boolean; error?: string };
+
+  if (result.success && result.needsSelect) {
+    await new Promise(resolve => setTimeout(resolve, 300));
+    const selectResult = await cometClient.evaluate(`
+      (() => {
+        const items = document.querySelectorAll('[role="menuitem"], [role="option"], button');
+        for (const item of items) {
+          if (item.innerText.toLowerCase().includes('${mode}')) {
+            item.click();
+            return { success: true };
+          }
+        }
+        return { success: false, error: "Mode option not found in dropdown" };
+      })()
+    `);
+    const selectRes = selectResult.result.value as { success: boolean; error?: string };
+    if (selectRes.success) {
+      return { success: true, content: `Switched to ${mode} mode` };
+    } else {
+      return { success: false, content: "", error: selectRes.error };
+    }
+  }
+
+  if (result.success) {
+    return { success: true, content: `Switched to ${mode} mode` };
+  } else {
+    return { success: false, content: "", error: result.error };
+  }
+}
+
+// ============================================================================
+// HTTP Server
+// ============================================================================
+
+/**
+ * Build CORS headers for a response.
+ *
+ * Returns an empty object when COMET_BRIDGE_CORS_ORIGIN is not set (server-
+ * to-server callers don't need CORS headers). Returns origin-specific headers
+ * when the env var is set to a specific origin.
+ *
+ * Wildcard ("*") is never emitted — the bridge uses bearer-token auth and
+ * wildcard CORS is unsafe in that combination.
+ */
+function corsHeaders(): Record<string, string> {
+  if (!CORS_ORIGIN) return {};
+  return {
+    "Access-Control-Allow-Origin": CORS_ORIGIN,
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+function sendJSON(res: http.ServerResponse, statusCode: number, data: unknown): void {
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json",
+    ...corsHeaders(),
+  });
+  res.end(JSON.stringify(data));
+}
+
+function parseBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", chunk => { body += chunk; });
+    req.on("end", () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Validate the bearer token using a timing-safe comparison.
+ *
+ * String equality (`===`) leaks the length of the matching prefix via
+ * timing differences — replaced with `crypto.timingSafeEqual`, which
+ * always takes the same time regardless of where strings diverge.
+ *
+ * Equal-length buffers are required by timingSafeEqual. If lengths differ
+ * we know immediately that the tokens don't match, but we still run the
+ * comparison on a zero-length buffer to avoid the timing difference caused
+ * by a short-circuit branch.
+ */
+function validateToken(req: http.IncomingMessage): boolean {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return false;
+
+  // Support both "Bearer <token>" and just "<token>"
+  const token = authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : authHeader;
+
+  const tokenBuf = Buffer.from(token);
+  const expectedBuf = Buffer.from(BRIDGE_TOKEN!);
+
+  if (tokenBuf.byteLength !== expectedBuf.byteLength) {
+    // Lengths differ — tokens cannot match, but still run a dummy comparison
+    // so the branch doesn't produce a measurable timing difference for
+    // tokens of the correct length.
+    timingSafeEqual(Buffer.alloc(1), Buffer.alloc(1));
+    return false;
+  }
+
+  return timingSafeEqual(tokenBuf, expectedBuf);
+}
+
+const server = http.createServer(async (req, res) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      ...corsHeaders(),
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url || "/", `http://${req.headers.host}`);
+  const path = url.pathname;
+
+  // Health check endpoint (no auth required)
+  if (path === "/health" && req.method === "GET") {
+    sendJSON(res, 200, {
+      status: "ok",
+      version: "2.7.0",
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+
+  // API info endpoint (no auth required)
+  if (path === "/" && req.method === "GET") {
+    sendJSON(res, 200, {
+      name: "comet-bridge",
+      version: "2.7.0",
+      description: "HTTP Bridge for Remote Comet MCP Access",
+      endpoints: {
+        "GET /health": "Health check",
+        "GET /tools": "List available tools",
+        "POST /tool/:name": "Execute a tool",
+        "POST /rpc": "JSON-RPC style endpoint",
+      },
+    });
+    return;
+  }
+
+  // All other endpoints require authentication
+  if (!validateToken(req)) {
+    sendJSON(res, 401, { error: "Unauthorized", message: "Invalid or missing token" });
+    return;
+  }
+
+  try {
+    // List tools
+    if (path === "/tools" && req.method === "GET") {
+      sendJSON(res, 200, {
+        tools: [
+          { name: "comet_connect", description: "Connect to Comet browser" },
+          { name: "comet_ask", description: "Send a prompt and get response" },
+          { name: "comet_poll", description: "Check agent status" },
+          { name: "comet_stop", description: "Stop current task" },
+          { name: "comet_screenshot", description: "Capture screenshot" },
+          { name: "comet_tabs", description: "Manage browser tabs" },
+          { name: "comet_mode", description: "Switch Perplexity mode" },
+          { name: "comet_upload", description: "Upload a file to a file input on the current page" },
+        ],
+      });
+      return;
+    }
+
+    // Execute tool via /tool/:name
+    const toolMatch = path.match(/^\/tool\/(\w+)$/);
+    if (toolMatch && req.method === "POST") {
+      const toolName = toolMatch[1];
+      const args = await parseBody(req) as Record<string, unknown>;
+      const result = await executeToolByName(toolName, args);
+      sendJSON(res, result.success ? 200 : 400, result);
+      return;
+    }
+
+    // JSON-RPC style endpoint
+    if (path === "/rpc" && req.method === "POST") {
+      const body = await parseBody(req) as { method?: string; params?: Record<string, unknown> };
+      if (!body.method) {
+        sendJSON(res, 400, { error: "Bad Request", message: "Missing 'method' field" });
+        return;
+      }
+      const result = await executeToolByName(body.method, body.params || {});
+      sendJSON(res, result.success ? 200 : 400, result);
+      return;
+    }
+
+    // 404 for unknown routes
+    sendJSON(res, 404, { error: "Not Found", message: `Unknown endpoint: ${path}` });
+
+  } catch (error) {
+    console.error("Server error:", error);
+    sendJSON(res, 500, {
+      error: "Internal Server Error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+async function executeToolByName(name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  switch (name) {
+    case "comet_connect":
+      return handleConnect();
+    case "comet_ask":
+      return handleAsk(args as { prompt: string; context?: string; newChat?: boolean; timeout?: number });
+    case "comet_poll":
+      return handlePoll();
+    case "comet_stop":
+      return handleStop();
+    case "comet_screenshot":
+      return handleScreenshot();
+    case "comet_tabs":
+      return handleTabs(args as { action?: string; domain?: string; tabId?: string });
+    case "comet_mode":
+      return handleMode(args as { mode?: string });
+    case "comet_upload":
+      return handleUpload(args as { filePath?: string; selector?: string; checkOnly?: boolean });
+    default:
+      return { success: false, content: "", error: `Unknown tool: ${name}` };
+  }
+}
+
+// ============================================================================
+// Start Server
+// ============================================================================
+
+server.listen(BRIDGE_PORT, BRIDGE_HOST, () => {
+  console.log(`
+╔═══════════════════════════════════════════════════════════════╗
+║           Comet MCP HTTP Bridge Server v2.7.0                 ║
+╠═══════════════════════════════════════════════════════════════╣
+║                                                               ║
+║  Status:    RUNNING                                           ║
+║  Host:      ${BRIDGE_HOST.padEnd(45)}║
+║  Port:      ${String(BRIDGE_PORT).padEnd(45)}║
+║  Auth:      Token-based (Authorization header)                ║
+║  CORS:      ${(CORS_ORIGIN ?? "disabled").padEnd(45)}║
+║                                                               ║
+║  Endpoints:                                                   ║
+║    GET  /health     - Health check (no auth)                  ║
+║    GET  /tools      - List available tools                    ║
+║    POST /tool/:name - Execute a tool                          ║
+║    POST /rpc        - JSON-RPC style calls                    ║
+║                                                               ║
+║  Example:                                                     ║
+║    curl -X POST http://localhost:${String(BRIDGE_PORT).padEnd(24)}║
+║         -H "Authorization: Bearer YOUR_TOKEN"                 ║
+║         -H "Content-Type: application/json"                   ║
+║         -d '{"method":"comet_connect"}'                       ║
+║                                                               ║
+╚═══════════════════════════════════════════════════════════════╝
+  `);
+});
+
+// Graceful shutdown
+process.on("SIGINT", () => {
+  console.log("\nShutting down HTTP bridge...");
+  server.close(() => {
+    process.exit(0);
+  });
+});
+
+process.on("SIGTERM", () => {
+  console.log("\nReceived SIGTERM, shutting down...");
+  server.close(() => {
+    process.exit(0);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,11 @@
 // Claude Code ↔ Perplexity Comet bidirectional interaction
 // Simplified to 6 essential tools
 
-import { readFileSync, existsSync, realpathSync, statSync } from "fs";
+import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
-import { dirname, join, resolve as resolvePath, sep as PATH_SEP } from "path";
-import { homedir } from "os";
+import { dirname, join } from "path";
 import { randomBytes } from "crypto";
+import { validateUploadPath, validateTabId } from "./upload-validator.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -76,87 +76,7 @@ function wrapUntrustedPageContent(text: string | null | undefined): string {
   ].join("\n");
 }
 
-/**
- * Validate a user-supplied upload path against the optional allowlist root
- * (`COMET_UPLOAD_ROOT` env). When the env var is set we resolve symlinks
- * and require the real path to live under the configured root — defends
- * against an LLM-controlled `filePath` exfiltrating arbitrary local files
- * (e.g. `~/.ssh/id_rsa`, `~/.aws/credentials`).
- *
- * When the env var is unset we keep the previous permissive behaviour
- * (backward compatibility) but still block a hardcoded denylist of paths
- * that obviously have no business being uploaded to a webpage.
- *
- * Returns the canonical absolute path, or throws with a user-facing message.
- */
-function validateUploadPath(filePath: string): string {
-  if (!existsSync(filePath)) {
-    throw new Error(`File not found: ${filePath}`);
-  }
-  const real = realpathSync(filePath); // resolve symlinks
-  const stat = statSync(real);
-  if (!stat.isFile()) {
-    throw new Error(`Not a regular file: ${filePath}`);
-  }
-
-  const root = process.env.COMET_UPLOAD_ROOT;
-  if (root) {
-    const realRoot = realpathSync(resolvePath(root));
-    const rootWithSep = realRoot.endsWith(PATH_SEP) ? realRoot : realRoot + PATH_SEP;
-    if (real !== realRoot && !real.startsWith(rootWithSep)) {
-      throw new Error(
-        `Refusing upload: path is outside COMET_UPLOAD_ROOT (${realRoot}). ` +
-        `Resolved path: ${real}`
-      );
-    }
-    return real;
-  }
-
-  // No allowlist configured. Still block obviously-sensitive paths to
-  // make the failure mode at least one step better than "anything goes".
-  const home = homedir();
-  const blockedPrefixes = [
-    resolvePath(home, ".ssh"),
-    resolvePath(home, ".aws"),
-    resolvePath(home, ".config", "gh"),
-    resolvePath(home, ".config", "gcloud"),
-    resolvePath(home, ".gnupg"),
-    resolvePath(home, ".kube"),
-    resolvePath(home, ".docker"),
-    resolvePath(home, "Library", "Keychains"), // macOS
-    "/etc/shadow",
-    "/etc/sudoers",
-    "/root",
-  ];
-  for (const prefix of blockedPrefixes) {
-    const withSep = prefix.endsWith(PATH_SEP) ? prefix : prefix + PATH_SEP;
-    if (real === prefix || real.startsWith(withSep)) {
-      throw new Error(
-        `Refusing upload from sensitive path: ${real}. ` +
-        `Set COMET_UPLOAD_ROOT to an explicit upload directory if this is intentional.`
-      );
-    }
-  }
-
-  console.error(
-    `[comet-mcp] WARN: comet_upload received '${real}' without COMET_UPLOAD_ROOT set. ` +
-    `Consider setting the env var to restrict allowed paths.`
-  );
-  return real;
-}
-
-/**
- * CDP target IDs are 32-char hex strings (typically uppercase). Reject
- * obviously-malformed values before passing to `Target.connect/close`,
- * which otherwise produce cryptic errors and can be tricked into
- * traversing the local HTTP API surface (`/json/version`, etc.).
- */
-function validateTabId(tabId: string): string {
-  if (!/^[A-Fa-f0-9-]{16,64}$/.test(tabId)) {
-    throw new Error(`Invalid tabId format: ${tabId}`);
-  }
-  return tabId;
-}
+// validateUploadPath and validateTabId are imported from ./upload-validator.js
 
 const TOOLS: Tool[] = [
   {

--- a/src/upload-validator.ts
+++ b/src/upload-validator.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared upload path and tab-ID validation utilities.
+ *
+ * Extracted from index.ts so that cdp-client.ts and http-bridge.ts can
+ * import them without introducing circular dependencies.
+ */
+
+import { realpathSync, statSync } from "fs";
+import { homedir } from "os";
+import { resolve as resolvePath, sep as PATH_SEP } from "path";
+
+/**
+ * Validate a user-supplied upload path against the optional allowlist root
+ * (`COMET_UPLOAD_ROOT` env). When the env var is set we resolve symlinks
+ * and require the real path to live under the configured root — defends
+ * against an LLM-controlled `filePath` exfiltrating arbitrary local files
+ * (e.g. `~/.ssh/id_rsa`, `~/.aws/credentials`).
+ *
+ * When the env var is unset we keep permissive behaviour (backward
+ * compatibility) but block a denylist of paths that obviously have no
+ * business being uploaded to a webpage.
+ *
+ * Security notes:
+ * - The former `existsSync` pre-check has been removed to eliminate the
+ *   TOCTOU window between existence check and `realpathSync`. A missing
+ *   path now produces an ENOENT from `realpathSync` which is caught and
+ *   re-thrown with a friendly message.
+ * - `COMET_UPLOAD_ROOT="/"` and `COMET_UPLOAD_ROOT=homedir()` are
+ *   explicitly rejected because they would pass every path through.
+ *
+ * Returns the canonical absolute path, or throws with a user-facing message.
+ */
+export function validateUploadPath(filePath: string): string {
+  // Atomically resolve the path (follows symlinks) and fail on ENOENT —
+  // no separate existsSync pre-check, which would introduce a TOCTOU race.
+  let real: string;
+  try {
+    real = realpathSync(filePath);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      throw new Error(`File not found: ${filePath}`);
+    }
+    throw err;
+  }
+
+  const stat = statSync(real);
+  if (!stat.isFile()) {
+    throw new Error(`Not a regular file: ${filePath}`);
+  }
+
+  const home = homedir();
+  const root = process.env.COMET_UPLOAD_ROOT;
+  if (root) {
+    // Reject dangerously broad root values before resolving.
+    const resolvedRoot = resolvePath(root);
+    if (resolvedRoot === "/" || resolvedRoot === home) {
+      throw new Error(
+        `COMET_UPLOAD_ROOT is set to an overly broad value ("${resolvedRoot}"). ` +
+        `Use a specific subdirectory (e.g., ~/uploads) to restrict allowed paths.`
+      );
+    }
+
+    let realRoot: string;
+    try {
+      realRoot = realpathSync(resolvedRoot);
+    } catch {
+      throw new Error(`COMET_UPLOAD_ROOT path does not exist: ${resolvedRoot}`);
+    }
+
+    // Also reject after symlink resolution (in case root itself is a symlink to /).
+    if (realRoot === "/" || realRoot === home) {
+      throw new Error(
+        `COMET_UPLOAD_ROOT resolves to an overly broad path ("${realRoot}"). ` +
+        `Use a specific subdirectory to restrict allowed paths.`
+      );
+    }
+
+    const rootWithSep = realRoot.endsWith(PATH_SEP) ? realRoot : realRoot + PATH_SEP;
+    if (real !== realRoot && !real.startsWith(rootWithSep)) {
+      throw new Error(
+        `Refusing upload: path is outside COMET_UPLOAD_ROOT (${realRoot}). ` +
+        `Resolved path: ${real}`
+      );
+    }
+    return real;
+  }
+
+  // No allowlist configured. Block obviously-sensitive paths to make the
+  // failure mode better than "anything goes".
+  const blockedPrefixes = [
+    resolvePath(home, ".ssh"),
+    resolvePath(home, ".aws"),
+    resolvePath(home, ".config", "gh"),
+    resolvePath(home, ".config", "gcloud"),
+    resolvePath(home, ".gnupg"),
+    resolvePath(home, ".kube"),
+    resolvePath(home, ".docker"),
+    resolvePath(home, "Library", "Keychains"), // macOS
+    // Credential and secret files
+    resolvePath(home, ".netrc"),
+    resolvePath(home, ".npmrc"),
+    resolvePath(home, ".git-credentials"),
+    resolvePath(home, ".pypirc"),
+    // Shell history (may contain secrets passed as CLI args)
+    resolvePath(home, ".bash_history"),
+    resolvePath(home, ".zsh_history"),
+    resolvePath(home, ".sh_history"),
+    // .env files at home root
+    resolvePath(home, ".env"),
+    // System-level sensitive paths
+    "/etc/shadow",
+    "/etc/sudoers",
+    "/etc/passwd",
+    "/root",
+    "/proc/self/environ", // exposes all env vars including secrets
+  ];
+
+  for (const prefix of blockedPrefixes) {
+    const withSep = prefix.endsWith(PATH_SEP) ? prefix : prefix + PATH_SEP;
+    if (real === prefix || real.startsWith(withSep)) {
+      throw new Error(
+        `Refusing upload from sensitive path: ${real}. ` +
+        `Set COMET_UPLOAD_ROOT to an explicit upload directory if this is intentional.`
+      );
+    }
+  }
+
+  // Block .env files anywhere in the filesystem (not just home root).
+  const basename = real.split(PATH_SEP).pop() ?? "";
+  if (basename === ".env" || basename.startsWith(".env.")) {
+    throw new Error(
+      `Refusing upload of environment file: ${real}. ` +
+      `Set COMET_UPLOAD_ROOT to an explicit upload directory if this is intentional.`
+    );
+  }
+
+  console.error(
+    `[comet-mcp] WARN: comet_upload received '${real}' without COMET_UPLOAD_ROOT set. ` +
+    `Consider setting the env var to restrict allowed paths.`
+  );
+  return real;
+}
+
+/**
+ * Validate a CDP tab ID.
+ *
+ * Chrome DevTools Protocol target IDs are UUID v4 strings. Reject
+ * obviously-malformed values before passing them to CDP methods, which
+ * otherwise produce cryptic errors and can be tricked into traversing the
+ * local HTTP API surface (`/json/version`, etc.).
+ *
+ * The original loose regex `/^[A-Fa-f0-9-]{16,64}$/` allowed hyphens in
+ * any position. This stricter version enforces canonical UUID v4 format.
+ */
+export function validateTabId(tabId: string): string {
+  const UUID_V4 =
+    /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/;
+  if (!UUID_V4.test(tabId)) {
+    throw new Error(`Invalid tabId format: ${tabId}`);
+  }
+  return tabId;
+}


### PR DESCRIPTION
## Summary

Addresses all 6 security vulnerabilities identified in the PR #14 review. Validators are extracted into a shared module, the HTTP bridge is brought under source control with fixes applied.

## Changes

- **`src/upload-validator.ts`** (new): Shared `validateUploadPath()` and `validateTabId()` — single source of truth for all callers.
  - Removes TOCTOU-prone `existsSync` pre-check; `realpathSync` now resolves atomically
  - Expands denylist: `~/.netrc`, `~/.npmrc`, `~/.git-credentials`, `~/.pypirc`, `/proc/self/environ`, shell histories, `.env` files anywhere on filesystem, `/etc/passwd`
  - Rejects `COMET_UPLOAD_ROOT="/"` and `COMET_UPLOAD_ROOT=homedir()` (before and after symlink resolution)
  - `validateTabId` tightened to strict UUID v4 regex

- **`src/index.ts`** (modified): Imports validators from shared module; removes inline definitions and unused imports

- **`src/cdp-client.ts`** (modified): Calls `validateUploadPath()` at entry of `uploadFile()` and `uploadFiles()` — defense-in-depth at the CDP layer

- **`src/http-bridge.ts`** (new — source for `dist/http-bridge.js`):
  - `crypto.timingSafeEqual` replaces timing-unsafe `===` for token comparison
  - CORS: no wildcard `*`; configurable via `COMET_BRIDGE_CORS_ORIGIN` env var
  - `validateTabId()` called in `handleTabs()` switch/close actions
  - `comet_upload` handler added with `validateUploadPath()` enforcement

## Testing

- [ ] Upload `~/.netrc` — expect rejection [type:manual]
- [ ] Upload with `COMET_UPLOAD_ROOT="/"` — expect "overly broad" error [type:manual]
- [ ] Symlink outside root when COMET_UPLOAD_ROOT is set — expect rejection [type:manual]
- [ ] HTTP bridge `GET /tools` includes `comet_upload` [type:api]
- [ ] HTTP bridge malformed tabId returns validation error [type:api]
- [ ] CORS headers absent when `COMET_BRIDGE_CORS_ORIGIN` unset [type:api]

---
Closes #24
**Implementation branch**: `fix/upload-path-security-24`
**Base**: `main`