### PR TITLE
fix(http-bridge): add validateSelector guard in handleUpload

### DIFF
--- a/src/http-bridge.ts
+++ b/src/http-bridge.ts
@@ -29,6 +29,7 @@ import {
   validateUploadPath,
   validateTabId,
   validateDomain,
+  validateSelector,
 } from "./upload-validator.js";
 
 // ============================================================================
@@ -601,6 +602,17 @@ async function handleUpload(args: {
         success: true,
         content: "No file input elements found on the current page.",
       };
+    }
+  }
+
+  // Defense-in-depth: validate the selector at the handler boundary
+  // before it reaches cdp-client.ts (which also validates). Keeps the
+  // HTTP bridge from forwarding obviously-invalid input any further.
+  if (args.selector !== undefined) {
+    try {
+      validateSelector(args.selector);
+    } catch (e: any) {
+      return { success: false, content: "", error: e.message };
     }
   }
 


### PR DESCRIPTION
## Summary

Adds defense-in-depth selector validation at the HTTP bridge handler boundary in \`handleUpload()\`. This mirrors the guard added to \`src/index.ts\` in PR #32, which left the parallel HTTP entry point unprotected.

The inner guard in \`cdp-client.ts\` still fires as a fallback — this is a consistency fix, not a functional vulnerability patch.

## Changes

- \`src/http-bridge.ts\`: Add \`validateSelector\` to import from \`upload-validator.js\`
- \`src/http-bridge.ts\`: Add conditional validation guard in \`handleUpload()\` before \`cometClient.uploadFile()\` call

## Testing

- [ ] POST /tools/comet_upload with valid selector: upload proceeds normally [type:api]
- [ ] POST /tools/comet_upload without selector: auto-detect still works (undefined guard) [type:api]
- [ ] POST /tools/comet_upload with malicious selector (e.g. `<script>`): returns structured error before reaching CDP [type:api]
- [ ] `npm run build` passes [type:unit]

---
Closes #33
**Implementation branch**: `fix/http-bridge-selector-validation-33`
**Base**: `main`