### PR TITLE
fix(security): tighten validateSelector allowlist — replace \s with [ \t] (#34)

### DIFF
--- a/src/upload-validator.ts
+++ b/src/upload-validator.ts
@@ -197,7 +197,8 @@ export function validateDomain(domain: string): string {
  *  - Maximum 500 characters — prevents a pathologically long selector from
  *    causing the Comet renderer to spend significant CPU time parsing (DoS).
  *  - Character allowlist covering the full CSS selector grammar: letters,
- *    digits, whitespace, and the punctuation characters used by class (`.`),
+ *    digits, space and tab (the only whitespace valid in CSS selectors), and
+ *    the punctuation characters used by class (`.`),
  *    ID (`#`), attribute (`[`, `]`, `=`, `~`, `^`, `$`, `*`, `|`),
  *    pseudo-class/element (`:`), combinators (`>`, `+`, `~`), grouping (`,`),
  *    quotes (`"`, `'`), parentheses, hyphens, underscores, and at-signs.
@@ -215,9 +216,12 @@ export function validateSelector(selector: string): string {
     throw new Error("Invalid selector: must be 1–500 characters long");
   }
   // Allowlist: CSS selector grammar characters only.
+  // Use explicit [ \t] instead of \s — \s also matches \n, \r, \f, \v which
+  // are not valid in CSS selectors and can corrupt error messages that echo
+  // the selector back to the caller.
   // Excludes: <, >, null bytes, and all other characters not used in CSS selectors.
   if (
-    !/^[A-Za-z0-9\s\.\#\[\]=~^$*|:>+,\"'\(\)\-_\\/@!;{}%&]+$/.test(selector)
+    !/^[A-Za-z0-9 \t\.\#\[\]=~^$*|:>+,\"'\(\)\-_\\/@!;{}%&]+$/.test(selector)
   ) {
     throw new Error(
       "Invalid selector: contains characters not permitted in CSS selectors",


### PR DESCRIPTION
## Summary

Fixes the `validateSelector()` allowlist in `src/upload-validator.ts` where `\s` was used as whitespace shorthand. `\s` in a JS regex character class matches `\n`, `\r`, `\f`, `\v`, and all Unicode whitespace — only space and tab are valid in CSS selectors.

This means a selector like `"div\nspan"` previously passed validation and could then be echoed into error messages (e.g. `No element found matching selector: div\nspan`), splitting the message across lines.

## Changes

- `src/upload-validator.ts:224`: replace `\s` → `[ \t]` in allowlist character class
- `src/upload-validator.ts:199-200`: JSDoc updated from "whitespace" to "space and tab (the only whitespace valid in CSS selectors)"  
- `src/upload-validator.ts:218-221`: inline comment explaining the `\s` → `[ \t]` rationale

## Testing

- [x] `validateSelector('div span')` → passes (space still valid)
- [x] `validateSelector('div\tnested')` → passes (tab still valid)
- [x] `validateSelector("div\nspan")` → throws (newline now rejected)
- [x] `validateSelector("div\rspan")` → throws (CR now rejected)
- [x] `validateSelector("div\fspan")` → throws (form feed now rejected)
- [x] `validateSelector("div\vspan")` → throws (vertical tab now rejected)
- [x] Complex selectors (`.class #id [attr="val"] > div + p`) → pass
- [x] `npm run build` — TypeScript compiles cleanly

---
Closes #34
**Implementation branch**: `fix/validate-selector-allowlist-34`
**Base**: `main`